### PR TITLE
Remove extra argument in call to log_err

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -433,7 +433,7 @@ do_master_register(void)
 	log_info(_("%s connected to master, checking its state\n"), progname);
 	if (is_standby(conn))
 	{
-		log_err(_("Trying to register as a master a standby node\n"), progname);
+		log_err(_("Trying to register as a master a standby node\n"));
 		PQfinish(conn);
 		exit(ERR_BAD_CONFIG);
 	}


### PR DESCRIPTION
You forgot to remove the extra argument to log_err in the last commit.
