### PR TITLE
Fix condition for node_name string comparision

### DIFF
--- a/config.c
+++ b/config.c
@@ -206,9 +206,9 @@ reload_configuration(char *config_file, t_configuration_options *orig_options)
 		return false;
 	}
 
-	if (new_options.node_name != orig_options->node_name)
+	if (strcmp(new_options.node_name, orig_options->node_name) != 0)
 	{
-		log_warning(_("\nCannot change standby name, will keep current configuration.\n"));
+		log_warning(_("\nCannot change node name, will keep current configuration.\n"));
 		return false;
 	}
 


### PR DESCRIPTION
Condition for node_name comparison between repmgr.conf and database configuration is currently broken. For string comparison it should use strcmp function.
