### PR TITLE
fix: store the master connection user name on standby follow

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -1494,6 +1494,7 @@ do_standby_follow(void)
 	 */
 	strncpy(runtime_options.host, PQhost(master_conn), MAXLEN);
 	strncpy(runtime_options.masterport, PQport(master_conn), MAXLEN);
+	strncpy(runtime_options.username, PQuser(master_conn), MAXLEN);
 	PQfinish(master_conn);
 
 	log_info(_("%s Changing standby's master\n"),progname);


### PR DESCRIPTION
Small fix to ensure the replication user is remembered when 'standby follow' is invoked.
