### PR TITLE
new commandline option to keep old postgresql.conf unchanged during standby clone

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -413,7 +413,7 @@ do_cluster_show(void)
 	log_info(_("%s connecting to database\n"), progname);
 	conn = establish_db_connection(options.conninfo, true);
 
-	sqlquery_snprintf(sqlquery, "SELECT conninfo, witness FROM %s.repl_nodes;",
+	sqlquery_snprintf(sqlquery, "SELECT conninfo, witness FROM %s.repl_nodes order by id;",
 					  repmgr_schema);
 	res = PQexec(conn, sqlquery);
 

--- a/repmgr.h
+++ b/repmgr.h
@@ -61,6 +61,7 @@ typedef struct
 	bool		force;
 	bool		wait_for_master;
 	bool		ignore_rsync_warn;
+	bool		preserve_config;
 
 	char		masterport[MAXLEN];
 	char		localport[MAXLEN];
@@ -71,6 +72,6 @@ typedef struct
 	char min_recovery_apply_delay[MAXLEN];
 }	t_runtime_options;
 
-#define T_RUNTIME_OPTIONS_INITIALIZER { "", "", "", "", "", "", DEFAULT_WAL_KEEP_SEGMENTS, false, false, false, false, "", "", 0, "" }
+#define T_RUNTIME_OPTIONS_INITIALIZER { "", "", "", "", "", "", DEFAULT_WAL_KEEP_SEGMENTS, false, false, false, false, false, "", "", 0, "" }
 
 #endif

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -1336,8 +1336,8 @@ usage(void)
 void
 help(const char *progname)
 {
-	printf(_("Usage: %s [OPTIONS]\n"), progname);
-	printf(_("Replicator manager daemon for PostgreSQL.\n"));
+	printf(_("\nReplicator manager daemon for PostgreSQL\n"));
+	printf(_("\nUsage: %s [OPTIONS]\n"), progname);
 	printf(_("\nOptions:\n"));
 	printf(_("  --help                    show this help, then exit\n"));
 	printf(_("  --version                 output version information, then exit\n"));


### PR DESCRIPTION
We use systems with different resources for standby servers (# of CPUs, RAM, disk types, etc.), and after an initial clone we don't want always correct the config to local settings, if force resync is required.
