### PR TITLE
Witness fixes: create a db and user to avoid using postgres

### DIFF
--- a/log.c
+++ b/log.c
@@ -37,7 +37,7 @@
 #define DEFAULT_SYSLOG_FACILITY LOG_LOCAL0
 #endif
 
-#define REPMGR_DEBUG
+/* #define REPMGR_DEBUG */
 
 void
 stderr_log_with_level(const char *level_name, int level, const char *fmt, ...)


### PR DESCRIPTION
This is a fix for https://groups.google.com/forum/#!topic/repmgr/5uv7tgVP0Dg so that the witness db can have a own db and own db user instead of using postgres user and postgres db.  Uses options from the command line that must be in alignment with config file.
