### PR TITLE
Fix witness' repl_monitor data inserts and copying master's configuratio...

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -2368,7 +2368,7 @@ static bool
 copy_configuration(PGconn *masterconn, PGconn *witnessconn)
 {
 	char		sqlquery[MAXLEN];
-	PGresult   *res;
+	PGresult   *res, *res2;
 	int			i;
 
 	sqlquery_snprintf(sqlquery, "TRUNCATE TABLE %s.repl_nodes", repmgr_schema);
@@ -2401,11 +2401,12 @@ copy_configuration(PGconn *masterconn, PGconn *witnessconn)
 						  atoi(PQgetvalue(res, i, 3)),
 						  PQgetvalue(res, i, 4));
 
-		res = PQexec(witnessconn, sqlquery);
-		if (!res || PQresultStatus(res) != PGRES_COMMAND_OK)
+		res2 = PQexec(witnessconn, sqlquery);
+		if (!res2 || PQresultStatus(res2) != PGRES_COMMAND_OK)
 		{
 			fprintf(stderr, "Cannot copy configuration to witness, %s\n",
 					PQerrorMessage(witnessconn));
+			PQclear(res2);
 			PQclear(res);
 			return false;
 		}

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -550,7 +550,7 @@ witness_monitor(void)
 	 */
 	sqlquery_snprintf(sqlquery,
 					  "INSERT INTO %s.repl_monitor "
-					  "VALUES(%d, %d, '%s'::timestamp with time zone, "
+					  "VALUES(%d, %d, '%s'::timestamp with time zone, null, "
 					  " pg_current_xlog_location(), null,  "
 					  " 0, 0)",
 					  repmgr_schema, primary_options.node, local_options.node,


### PR DESCRIPTION
Don't overwrite `res` when copying the configuration from the master, this allows repmgrd to start properly in witness mode on witness nodes.

Adjust `INSERT` statement to have correct number of fields so it works, in case `--monitoring-history` is being used. 
