### PR TITLE
Add demote_command option for master failure/shutdown (complement of promote_command)

### DIFF
--- a/config.c
+++ b/config.c
@@ -42,6 +42,7 @@ parse_config(const char *config_file, t_configuration_options * options)
 	memset(options->promote_command, 0, sizeof(options->promote_command));
 	memset(options->follow_command, 0, sizeof(options->follow_command));
 	memset(options->demote_command, 0, sizeof(options->demote_command));
+	memset(options->gateway, 0, sizeof(options->gateway));
 	memset(options->rsync_options, 0, sizeof(options->rsync_options));
 	memset(options->ssh_options, 0, sizeof(options->ssh_options));
 	memset(options->pg_bindir, 0, sizeof(options->pg_bindir));
@@ -119,6 +120,8 @@ parse_config(const char *config_file, t_configuration_options * options)
 			strncpy(options->follow_command, value, MAXLEN);
 		else if (strcmp(name, "demote_command") == 0)
 			strncpy(options->demote_command, value, MAXLEN);
+		else if (strcmp(name, "gateway") == 0)
+			strncpy(options->gateway, value, MAXLEN);
 		else if (strcmp(name, "master_response_timeout") == 0)
 			options->master_response_timeout = atoi(value);
 		else if (strcmp(name, "reconnect_attempts") == 0)
@@ -316,6 +319,7 @@ reload_config(char *config_file, t_configuration_options * orig_options)
 	strcpy(orig_options->promote_command, new_options.promote_command);
 	strcpy(orig_options->follow_command, new_options.follow_command);
 	strcpy(orig_options->demote_command, new_options.demote_command);
+	strcpy(orig_options->gateway, new_options.gateway);
 	strcpy(orig_options->rsync_options, new_options.rsync_options);
 	strcpy(orig_options->ssh_options, new_options.ssh_options);
 	orig_options->master_response_timeout = new_options.master_response_timeout;

--- a/config.c
+++ b/config.c
@@ -41,6 +41,7 @@ parse_config(const char *config_file, t_configuration_options * options)
 	memset(options->node_name, 0, sizeof(options->node_name));
 	memset(options->promote_command, 0, sizeof(options->promote_command));
 	memset(options->follow_command, 0, sizeof(options->follow_command));
+	memset(options->demote_command, 0, sizeof(options->demote_command));
 	memset(options->rsync_options, 0, sizeof(options->rsync_options));
 	memset(options->ssh_options, 0, sizeof(options->ssh_options));
 	memset(options->pg_bindir, 0, sizeof(options->pg_bindir));
@@ -116,6 +117,8 @@ parse_config(const char *config_file, t_configuration_options * options)
 			strncpy(options->promote_command, value, MAXLEN);
 		else if (strcmp(name, "follow_command") == 0)
 			strncpy(options->follow_command, value, MAXLEN);
+		else if (strcmp(name, "demote_command") == 0)
+			strncpy(options->demote_command, value, MAXLEN);
 		else if (strcmp(name, "master_response_timeout") == 0)
 			options->master_response_timeout = atoi(value);
 		else if (strcmp(name, "reconnect_attempts") == 0)
@@ -312,6 +315,7 @@ reload_config(char *config_file, t_configuration_options * orig_options)
 	strcpy(orig_options->node_name, new_options.node_name);
 	strcpy(orig_options->promote_command, new_options.promote_command);
 	strcpy(orig_options->follow_command, new_options.follow_command);
+	strcpy(orig_options->demote_command, new_options.demote_command);
 	strcpy(orig_options->rsync_options, new_options.rsync_options);
 	strcpy(orig_options->ssh_options, new_options.ssh_options);
 	orig_options->master_response_timeout = new_options.master_response_timeout;

--- a/config.h
+++ b/config.h
@@ -33,6 +33,7 @@ typedef struct
 	char		node_name[MAXLEN];
 	char		promote_command[MAXLEN];
 	char		follow_command[MAXLEN];
+	char		demote_command[MAXLEN];
 	char		loglevel[MAXLEN];
 	char		logfacility[MAXLEN];
 	char		rsync_options[QUERY_STR_LEN];
@@ -47,7 +48,7 @@ typedef struct
 	int			retry_promote_interval_secs;
 }	t_configuration_options;
 
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", -1, -1, -1, "", "", "", 0, 0 }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", 0, 0 }
 
 void		parse_config(const char *config_file, t_configuration_options * options);
 void		parse_line(char *buff, char *name, char *value);

--- a/config.h
+++ b/config.h
@@ -34,6 +34,7 @@ typedef struct
 	char		promote_command[MAXLEN];
 	char		follow_command[MAXLEN];
 	char		demote_command[MAXLEN];
+	char		gateway[MAXLEN];
 	char		loglevel[MAXLEN];
 	char		logfacility[MAXLEN];
 	char		rsync_options[QUERY_STR_LEN];
@@ -48,7 +49,7 @@ typedef struct
 	int			retry_promote_interval_secs;
 }	t_configuration_options;
 
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", 0, 0 }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", 0, 0 }
 
 void		parse_config(const char *config_file, t_configuration_options * options);
 void		parse_line(char *buff, char *name, char *value);

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -148,8 +148,6 @@ is_gwup(const char *host)
 
 	snprintf(command, MAXLEN, "ping -c1 -q -t1 %s", host);
 
-    log_debug(_("gateway check command is: \"%s\"\n"), command);
-
     return system(command) == 0;
 }
 
@@ -1282,6 +1280,7 @@ check_gateway(const char *host)
 		log_err(_("%s: We couldn't reconnect for long enough, stopping postgresql master..., exiting...\n"),
 				progname);
         maxlen_snprintf(script, "%s/pg_ctl %s -m fast stop", local_options.pg_bindir, local_options.pgctl_options);
+        log_info(_("%s: %s.\n"), progname, script);
         r = system(script);
         if (r != 0)
         {

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -169,6 +169,7 @@ main(int argc, char **argv)
 	};
 
 	int			optindex;
+    int         r;
 	int			c,
 				ret;
 	bool		daemonize = false;
@@ -372,6 +373,21 @@ main(int argc, char **argv)
 						/*
 						 * XXX May we do something more verbose ?
 						 */
+                        log_debug(_("demote command is: \"%s\"\n"), local_options.demote_command);
+
+                        if (log_type == REPMGR_STDERR && *local_options.logfile)
+                        {
+                            fflush(stderr);
+                        }
+
+                        r = system(local_options.demote_command);
+                        if (r != 0)
+                        {
+                            log_err(_("%s: demote command failed. You could check and try it manually.\n"),
+                                    progname);
+                            terminate(ERR_BAD_CONFIG);
+                        }
+
 						terminate(1);
 					}
 


### PR DESCRIPTION
Hi,

I would like to add a 'demote_command' option (similar to promote_command). This command gets executed on a master node when master fails/shuts down.

I use repmgr to manage a virtual IP of my postgresql master. I use promote_command to set up this virtual IP via 'ip addr add ...' and 'arping -U ...' I need the demote_command to release the virtual IP from the master node via 'ip addr del ...'

Having the demote_command option makes it possible to do any such cleanup actions on the master when master fails/shuts down. It enables to reverse the promote_command actions when necessary (for example when managing virtual IP of master postgres db via repmgr).

Happy to answer any questions/do some more work on this pull request.

Cheers,
Tomas
