### PR TITLE
Fix markup

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -50,8 +50,8 @@ Installation
   see README.rst for further details.
 
 * Source installation
- - `repmgr` source code is hosted at github (https://github.com/2ndQuadrant/`repmgr`);
-   tar.gz files can be downloaded from https://github.com/2ndQuadrant/`repmgr`/releases .
+ - `repmgr` source code is hosted at github (https://github.com/2ndQuadrant/repmgr);
+   tar.gz files can be downloaded from https://github.com/2ndQuadrant/repmgr/releases .
 
    `repmgr` can be built easily using PGXS:
 


### PR DESCRIPTION
This was broken in commit  8faf41dd94b01aa0735a6ba8b9ead60b65065ac1,
most likely because of a runaway search/replace.