### PR TITLE
Check and keep periodically witness' repl_nodes table uptodate.

### DIFF
--- a/dbutils.h
+++ b/dbutils.h
@@ -60,7 +60,7 @@ bool		start_backup(PGconn *conn, char *first_wal_segment, bool fast_checkpoint);
 bool		stop_backup(PGconn *conn, char *last_wal_segment);
 bool		set_config_bool(PGconn *conn, const char *config_param, bool state);
 bool		copy_configuration(PGconn *masterconn, PGconn *witnessconn, char *cluster_name);
-bool		create_node_record(PGconn *conn, char *action, int node, char *type, int upstream_node, char *cluster_name, char *node_name, char *conninfo, int priority, char *slot_name);
+bool		create_node_record(PGconn *conn, char *action, int node, char *type, int upstream_node, char *cluster_name, char *node_name, char *conninfo, int priority, char *slot_name, bool active);
 bool		delete_node_record(PGconn *conn, int node, char *action);
 bool        create_event_record(PGconn *conn, t_configuration_options *options, int node_id, char *event, bool successful, char *details);
 

--- a/repmgr.c
+++ b/repmgr.c
@@ -776,7 +776,7 @@ do_master_register(void)
 										options.node_name,
 										options.conninfo,
 										options.priority,
-										repmgr_slot_name_ptr);
+										repmgr_slot_name_ptr, true);
 
 	if(record_created == false)
 	{
@@ -874,7 +874,7 @@ do_standby_register(void)
 										options.node_name,
 										options.conninfo,
 										options.priority,
-										repmgr_slot_name_ptr);
+										repmgr_slot_name_ptr, true);
 
 
 
@@ -2114,7 +2114,7 @@ do_witness_create(void)
 										options.node_name,
 										options.conninfo,
 										options.priority,
-										NULL);
+										NULL, true);
 
 	if(record_created == false)
 	{

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-
+#include <string.h>
 
 
 #include "repmgr.h"
@@ -527,6 +527,7 @@ witness_monitor(void)
 {
 	char		monitor_witness_timestamp[MAXLEN];
 	PGresult   *res;
+	PGresult   *res_master;
 	char		sqlquery[QUERY_STR_LEN];
 	bool        connection_ok;
 
@@ -609,6 +610,38 @@ witness_monitor(void)
 			terminate(ERR_DB_CON);
 		}
 	}
+	/*
+	 * Compair repl_nodes content between local and master conn.
+	 */
+	sqlquery_snprintf(sqlquery, "SELECT md5(array_to_string(array("
+								"			SELECT repl_nodes::TEXT FROM %s.repl_nodes ORDER BY id"
+								"		), ','))",
+								get_repmgr_schema_quoted(my_local_conn));
+	res = PQexec(my_local_conn, sqlquery);
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		log_err(_("PQexec failed: %s\n"), PQerrorMessage(my_local_conn));
+		PQclear(res);
+		/* if there is any error just let it be and retry in next loop */
+		return;
+	}
+	res_master = PQexec(master_conn, sqlquery);
+	if (PQresultStatus(res_master) != PGRES_TUPLES_OK)
+	{
+		log_err(_("PQexec failed: %s\n"), PQerrorMessage(master_conn));
+		PQclear(res_master);
+		/* if there is any error just let it be and retry in next loop */
+		return;
+	}
+
+	if (strncmp((char *) PQgetvalue(res, 0, 0), (char*) PQgetvalue(res_master, 0, 0), 32) != 0)
+	{
+		log_warning(_("Local and master %s.repl_nodes tables content differ, syncing it from master.\n"), get_repmgr_schema_quoted(my_local_conn));
+		copy_configuration(master_conn, my_local_conn, local_options.cluster_name);
+	} else
+		log_debug(_("Local and master %s.repl_nodes tables content are identical.\n"), get_repmgr_schema_quoted(my_local_conn));
+	PQclear(res);
+	PQclear(res_master);
 
 	/* Fast path for the case where no history is requested */
 	if (!monitoring_history)


### PR DESCRIPTION
Witness' repl_nodes table is sync'ed from master only when a new master
is promoted, this behaviour can leads to issues: when a new standby is
added to the cluster *after* a new master has been promoted, witness' repl_nodes
table won't contain any row related to this new standby, if a new failover
occurs this situation can be confusing for other standbys and the follow
operation can fail.

This patch compares periodically md5 sum of master's repl_nodes tables content (serialized)
with the local one in witness_monitor(), if both md5 sum are not equals then
it calls copy_configuration().