### PR TITLE
Add recovery restore_command option

### DIFF
--- a/config.c
+++ b/config.c
@@ -126,6 +126,7 @@ parse_config(const char *config_file, t_configuration_options *options)
 	memset(options->pg_bindir, 0, sizeof(options->pg_bindir));
 	memset(options->pg_ctl_options, 0, sizeof(options->pg_ctl_options));
 	memset(options->pg_basebackup_options, 0, sizeof(options->pg_basebackup_options));
+	memset(options->recovery_restore_command, 0, sizeof(options->recovery_restore_command));
 
 	/* default master_response_timeout is 60 seconds */
 	options->master_response_timeout = 60;
@@ -223,6 +224,8 @@ parse_config(const char *config_file, t_configuration_options *options)
 			options->use_replication_slots = atoi(value);
 		else if (strcmp(name, "event_notification_command") == 0)
 			strncpy(options->event_notification_command, value, MAXLEN);
+		else if (strcmp(name, "recovery_restore_command") == 0)
+			strncpy(options->recovery_restore_command, value, MAXLEN);
 		else if (strcmp(name, "event_notifications") == 0)
 			parse_event_notifications_list(options, value);
 		else if (strcmp(name, "tablespace_mapping") == 0)
@@ -493,6 +496,12 @@ reload_config(char *config_file, t_configuration_options * orig_options)
 		config_changed = true;
 	}
 
+	/* recovery_restore_command */
+	if(strcmp(orig_options->recovery_restore_command, new_options.recovery_restore_command) != 0)
+	{
+		strcpy(orig_options->recovery_restore_command, new_options.recovery_restore_command);
+		config_changed = true;
+	}
 	/*
 	 * XXX These ones can change with a simple SIGHUP?
 	 *

--- a/config.h
+++ b/config.h
@@ -76,11 +76,12 @@ typedef struct
 	int			retry_promote_interval_secs;
 	int			use_replication_slots;
 	char		event_notification_command[MAXLEN];
+	char		recovery_restore_command[MAXLEN];
 	EventNotificationList event_notifications;
 	TablespaceList tablespace_mapping;
 }	t_configuration_options;
 
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", 0, 0, 0, "", "", { NULL, NULL }, {NULL, NULL} }
 
 
 bool		parse_config(const char *config_file, t_configuration_options *options);

--- a/repmgr.c
+++ b/repmgr.c
@@ -2309,7 +2309,7 @@ create_recovery_file(const char *data_dir)
 	/* primary_slot_name = '...' (optional, for fetching WAL from an alternate archive) */
 	if(strlen(options.recovery_restore_command) != 0)
 	{
-		maxlen_snprintf(line, "restore_command = %s\n",
+		maxlen_snprintf(line, "restore_command = '%s'\n",
 						options.recovery_restore_command);
 		if(write_recovery_file_line(recovery_file, recovery_file_path, line) == false)
 			return false;

--- a/repmgr.c
+++ b/repmgr.c
@@ -2306,6 +2306,16 @@ create_recovery_file(const char *data_dir)
 		log_debug(_("recovery.conf: %s"), line);
 	}
 
+	/* primary_slot_name = '...' (optional, for fetching WAL from an alternate archive) */
+	if(strlen(options.recovery_restore_command) != 0)
+	{
+		maxlen_snprintf(line, "restore_command = %s\n",
+						options.recovery_restore_command);
+		if(write_recovery_file_line(recovery_file, recovery_file_path, line) == false)
+			return false;
+
+		log_debug(_("recovery.conf: %s"), line);
+	}
 	/* primary_slot_name = '...' (optional, for 9.4 and later) */
 	if(options.use_replication_slots)
 	{


### PR DESCRIPTION
This is an alternative to the repmgr approach of suggesting to raise `wal_keep_segments`. 
On our usecase, we have big databases with lots of activity, where rsyncing/base_backuping can take hours.
So, when the slave wants to get up to date with the master, all segments have been archived unless `wal_keep_segments` is raised to an absurd amount.

However, we do keep all the segments archived in WAL-E. So the approach we've taken is to add both the master connection info and a `recovery_restore` command on recovery.conf, so segments already removed on the master can be fetched from an alternate source.

This adds an optional config parameter called `recovery_restore_command`, which will inject a `restore_command` on the recovery.conf created by repmgr. 
We use it to point to a WAL-E wal-fetch command configured to where the master is archiving, but it should be usable with any other archival system.

(This PR is still lacking documentation, but I can add it if you consider merging it)