### PR TITLE
add the ability to have a command run at master or standby startup

### DIFF
--- a/config.c
+++ b/config.c
@@ -121,6 +121,8 @@ parse_config(const char *config_file, t_configuration_options *options)
 	memset(options->node_name, 0, sizeof(options->node_name));
 	memset(options->promote_command, 0, sizeof(options->promote_command));
 	memset(options->follow_command, 0, sizeof(options->follow_command));
+	memset(options->master_startup_command, 0, sizeof(options->master_startup_command));
+	memset(options->standby_startup_command, 0, sizeof(options->standby_startup_command));
 	memset(options->rsync_options, 0, sizeof(options->rsync_options));
 	memset(options->ssh_options, 0, sizeof(options->ssh_options));
 	memset(options->pg_bindir, 0, sizeof(options->pg_bindir));
@@ -201,6 +203,10 @@ parse_config(const char *config_file, t_configuration_options *options)
 			strncpy(options->promote_command, value, MAXLEN);
 		else if (strcmp(name, "follow_command") == 0)
 			strncpy(options->follow_command, value, MAXLEN);
+		else if (strcmp(name, "master_startup_command") == 0)
+			strncpy(options->master_startup_command, value, MAXLEN);
+		else if (strcmp(name, "standby_startup_command") == 0)
+			strncpy(options->standby_startup_command, value, MAXLEN);
 		else if (strcmp(name, "master_response_timeout") == 0)
 			options->master_response_timeout = atoi(value);
 		else if (strcmp(name, "reconnect_attempts") == 0)
@@ -490,6 +496,20 @@ reload_config(char *config_file, t_configuration_options * orig_options)
 	if(strcmp(orig_options->follow_command, new_options.follow_command) != 0)
 	{
 		strcpy(orig_options->follow_command, new_options.follow_command);
+		config_changed = true;
+	}
+
+	/* master_startup_command */
+	if(strcmp(orig_options->master_startup_command, new_options.master_startup_command) != 0)
+	{
+		strcpy(orig_options->master_startup_command, new_options.master_startup_command);
+		config_changed = true;
+	}
+
+	/* standby_startup_command */
+	if(strcmp(orig_options->standby_startup_command, new_options.standby_startup_command) != 0)
+	{
+		strcpy(orig_options->standby_startup_command, new_options.standby_startup_command);
 		config_changed = true;
 	}
 

--- a/config.h
+++ b/config.h
@@ -61,6 +61,10 @@ typedef struct
 	char		node_name[MAXLEN];
 	char		promote_command[MAXLEN];
 	char		follow_command[MAXLEN];
+	//This command will be run on startup if the current node is the master.
+	char		master_startup_command[MAXLEN];
+	//This command will be run on startup if the current node is a standby.
+	char		standby_startup_command[MAXLEN];
 	char		loglevel[MAXLEN];
 	char		logfacility[MAXLEN];
 	char		rsync_options[QUERY_STR_LEN];
@@ -80,7 +84,7 @@ typedef struct
 	TablespaceList tablespace_mapping;
 }	t_configuration_options;
 
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
 
 
 bool		parse_config(const char *config_file, t_configuration_options *options);

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -152,6 +152,7 @@ main(int argc, char **argv)
 
 	int			optindex;
 	int			c;
+	int 		r;
 	bool		daemonize = false;
 	bool        startup_event_logged = false;
 
@@ -339,6 +340,14 @@ main(int argc, char **argv)
 					startup_event_logged = true;
 				}
 
+				r = system(local_options.master_startup_command);
+
+				if (r != 0)
+				{
+					log_err(_("Execution of master_startup_command failed. You could check and try it manually.\n"));
+					terminate(ERR_DB_QUERY);
+				}
+
 				log_info(_("starting continuous master connection check\n"));
 
 				/*
@@ -399,6 +408,15 @@ main(int argc, char **argv)
 
 			case WITNESS:
 			case STANDBY:
+
+				//Perform standby_startup before attempting to connect to the master, in case it does some network configuration.
+				r = system(local_options.standby_startup_command);
+
+				if (r != 0)
+				{
+					log_err(_("Execution of standby_startup_command failed. You could check and try it manually.\n"));
+					terminate(ERR_DB_QUERY);
+				}
 
 				/* We need the node id of the master server as well as a connection to it */
 				log_info(_("connecting to master node '%s'\n"),


### PR DESCRIPTION
I used these options to make it so that the slave could drop the floating postgresql IP address if it had it, and the master could take the floating IP address on startup. I'm sure people could come up with other uses, also.
