### PR TITLE
Ignore comments after values

### DIFF
--- a/config.c
+++ b/config.c
@@ -383,6 +383,8 @@ parse_line(char *buff, char *name, char *value)
 	for (++i; i < MAXLEN; ++i)
 		if (buff[i] == '\'')
 			continue;
+		else if (buff[i] == '#')
+			break;
 		else if (buff[i] != '\n')
 			value[j++] = buff[i];
 		else


### PR DESCRIPTION
With the recent changes, this is the last one to enable repmgr to read the provided example repmgr.conf file, as per #84 