### PR TITLE
Fix long option name for -D to --data-dir

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -129,7 +129,7 @@ main(int argc, char **argv)
 		{"port", required_argument, NULL, 'p'},
 		{"username", required_argument, NULL, 'U'},
 		{"superuser", required_argument, NULL, 'S'},
-		{"dest-dir", required_argument, NULL, 'D'},
+		{"data-dir", required_argument, NULL, 'D'},
 		{"local-port", required_argument, NULL, 'l'},
 		{"config-file", required_argument, NULL, 'f'},
 		{"remote-user", required_argument, NULL, 'R'},


### PR DESCRIPTION
Hi,

When using repmgr with `--data-dir`, it raises the following error:
```
[ERROR] Unknown option '--data-dir'
```

This is not consistent with the embedded help message:
```
Configuration options:
  -b, --pg_bindir=PATH                path to PostgreSQL binaries (optional)
  -D, --data-dir=DIR                  local directory where the files will be
                                      copied to
```

Regards,