### PR TITLE
Bug #90 fix (autofailover with reconnect_attemps > 1).

### DIFF
--- a/errcode.h
+++ b/errcode.h
@@ -35,5 +35,6 @@
 #define ERR_BAD_SSH 12
 #define ERR_SYS_FAILURE 13
 #define ERR_BAD_BASEBACKUP 14
+#define ERR_INTERNAL 15
 
 #endif   /* _ERRCODE_H_ */


### PR DESCRIPTION
The main change is that now check_connection requires a conninfo
parameter, and the connection object has type (PGconn **) so it can be
replaced by check_connection if needed.

The bug was caused by the fact that the first failure resulted in
*conn == NULL, so that subsequent checks of the upstream connection
were failing irrespectively of the actual state of the upstream node.

Now, when *conn == NULL, check_connection will use conninfo to
establish a new connection and place it into *conn. We introduce a new
INTERNAL_ERROR code for the case when they are both NULL.

In passing, we also reworded a confusing error message, distinguishing
a timeout from the actual elapsed time.