### PR TITLE
Debian init script repmgrd process stop fix

### DIFF
--- a/debian/repmgr.repmgrd.init
+++ b/debian/repmgr.repmgrd.init
@@ -59,7 +59,7 @@ do_stop()
 	#   0 if daemon has been stopped
 	#   1 if daemon was already stopped
 	#   other if daemon could not be stopped or a failure occurred
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $REPMGRD_PIDFILE --exec $REPMGRD_BIN
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $REPMGRD_PIDFILE --name "$(basename $REPMGRD_BIN)"
 }
 
 case "$1" in


### PR DESCRIPTION
Postgresql under Debian Linux has various wrappers and symlinks, so the final path of the running process differs from the name started. The start-stop-daemon always spawns another repmgrd process without this fix.
