### PR TITLE
Remove --exec from start-stop-daemon on stop.

### DIFF
--- a/debian/repmgr.repmgrd.init
+++ b/debian/repmgr.repmgrd.init
@@ -59,7 +59,7 @@ do_stop()
 	#   0 if daemon has been stopped
 	#   1 if daemon was already stopped
 	#   other if daemon could not be stopped or a failure occurred
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $REPMGRD_PIDFILE --exec $REPMGRD_BIN
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $REPMGRD_PIDFILE
 }
 
 case "$1" in


### PR DESCRIPTION
When `repmgr` is started the `/usr/lib/postgresql/9.4/bin/repmgrd`
binary is executed. The `stop` operation is looking for
`usr/bin/repmgrd` which is not found in the process table.

Removing the `--exec` option from the `stop` action fix that issue and
allow a clean stop of `repmrgd`.

```
root@pg02:~# /etc/init.d/repmgrd stop
 * Stopping PostgreSQL replication management and monitoring daemon repmgrd                   [ OK ]
root@pg02:~# ps aux | grep repmgr
postgres 17915  0.1  0.0  92520  4648 ?        S    14:10   0:00 /usr/lib/postgresql/9.4/bin/repmgrd --config-file /etc/repmgr/repmgr.conf
postgres 17918  0.0  0.0 253044  7264 ?        Ss   14:10   0:00 postgres: repmgr repmgr 172.18.60.71(20981) idle
root     17987  0.0  0.0  10464   948 pts/2    S+   14:12   0:00 grep --color=auto repmgr
root@pg02:~#
```