### PR TITLE
Fix failed standby

### DIFF
--- a/repmgrd.c
+++ b/repmgrd.c
@@ -690,18 +690,12 @@ standby_monitor(void)
 		initPQExpBuffer(&errmsg);
 
 		appendPQExpBuffer(&errmsg,
-						  _("failed to connect to local node, node marked as failed and terminating!"));
+						  _("failed to connect to local node, node marked as failed!"));
 
 		log_err("%s\n", errmsg.data);
 
-		create_event_record(master_conn,
-							&local_options,
-							local_options.node,
-							"repmgrd_shutdown",
-							false,
-							errmsg.data);
-
-		terminate(ERR_DB_CON);
+		//terminate(ERR_DB_CON);
+		goto continue_monitoring_standby;
 	}
 
 	upstream_conn = get_upstream_connection(my_local_conn,
@@ -830,6 +824,7 @@ standby_monitor(void)
 
 	PQfinish(upstream_conn);
 
+ continue_monitoring_standby:
 	/* Check if we still are a standby, we could have been promoted */
 	do
 	{

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -861,26 +861,23 @@ standby_monitor(void)
 					 * Let's continue checking, and if the postgres server on the
 					 * standby comes back up, we will activate it again
 					 */
-					continue;
 				}
 
 				break;
-		        case 1:
-			       /*
-				* There's a possible situation where the standby went down for some reason
-				* (maintanence for example) and is now up and maybe connected once again to
-				* the stream. If we set the local standby node as failed and it's now running
-				* and receiving replication data, we should re-enable it.
-				*/
-			       set_local_node_status();
-			       break;
 		  
 		}
 	} while (ret == -1);
 
 	if (did_retry)
 	{
-		log_info(_("standby connection recovered!\n"));
+	        /*
+		 * There's a possible situation where the standby went down for some reason
+		 * (maintanence for example) and is now up and maybe connected once again to
+		 * the stream. If we set the local standby node as failed and it's now running
+		 * and receiving replication data, we should activate it again.
+		 */
+	        set_local_node_status();
+	        log_info(_("standby connection recovered!\n"));
 	}
 
 	/* Fast path for the case where no history is requested */


### PR DESCRIPTION
The patches are so that repmgrd can recover a failed standby server. Now it will not terminate as often as it did, because we want it to keep checking, just in case the standby went down for maintenance for example.