### PR TITLE
FAQ.md: Values less than 0 are no longer supported

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -149,7 +149,7 @@ General
 
 - How can I prevent a node from ever being promoted to master?
 
-  In `repmgr.conf`, set its priority to a value of 0 or less.
+  In `repmgr.conf`, set its priority to a value of 0.
 
 - Does `repmgrd` support delayed standbys?
 


### PR DESCRIPTION
Documentation recommended a value of 0 or less for `priority`, which has been
unsupported since some config parsing rewrites in November.