### PR TITLE
Replace non-POSIX dirent.d_type with stat.st_mode (fixes build on illumos)

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -3286,6 +3286,7 @@ do_standby_restore_config(void)
 {
 	DIR			  *arcdir;
 	struct dirent *arcdir_ent;
+	struct stat	   arcdir_statbuf;
 	int			   copied_count = 0;
 	bool		   copy_ok = true;
 
@@ -3300,7 +3301,7 @@ do_standby_restore_config(void)
 		PQExpBufferData src_file;
 		PQExpBufferData dst_file;
 
-		if (arcdir_ent->d_type != DT_REG)
+		if (stat(arcdir_ent->d_name, &arcdir_statbuf) == -1 || !S_ISDIR(arcdir_statbuf.st_mode))
 		{
 			continue;
 		}


### PR DESCRIPTION
This is a small pull request that changes the non-POSIX usage of `struct dirent` with member `d_type` to instead call [`stat(2)`](https://illumos.org/man/2/stat) and use the POSIX compatible [`S_ISDIR`](https://illumos.org/man/3HEAD/stat.h) macro.

This is primarily due to [`struct dirent`](https://illumos.org/man/3HEAD/dirent.h) not having a `d_type` member on illumos/solaris derived operating systems.

**TL;DR** Couldn't get repmgr to build on SmartOS, now it can with this change.  Also tested the changes on OS X and Linux.