### PR TITLE
Provide start/stop/restart command overrides via repmgr.conf

### DIFF
--- a/config.c
+++ b/config.c
@@ -219,6 +219,9 @@ parse_config(t_configuration_options *options)
 	memset(options->node_name, 0, sizeof(options->node_name));
 	memset(options->promote_command, 0, sizeof(options->promote_command));
 	memset(options->follow_command, 0, sizeof(options->follow_command));
+	memset(options->stop_command, 0, sizeof(options->stop_command));
+	memset(options->start_command, 0, sizeof(options->start_command));
+	memset(options->restart_command, 0, sizeof(options->restart_command));
 	memset(options->rsync_options, 0, sizeof(options->rsync_options));
 	memset(options->ssh_options, 0, sizeof(options->ssh_options));
 	memset(options->pg_bindir, 0, sizeof(options->pg_bindir));
@@ -339,6 +342,12 @@ parse_config(t_configuration_options *options)
 			strncpy(options->promote_command, value, MAXLEN);
 		else if (strcmp(name, "follow_command") == 0)
 			strncpy(options->follow_command, value, MAXLEN);
+		else if (strcmp(name, "stop_command") == 0)
+			strncpy(options->stop_command, value, MAXLEN);
+		else if (strcmp(name, "start_command") == 0)
+			strncpy(options->start_command, value, MAXLEN);
+		else if (strcmp(name, "restart_command") == 0)
+			strncpy(options->restart_command, value, MAXLEN);
 		else if (strcmp(name, "master_response_timeout") == 0)
 			options->master_response_timeout = repmgr_atoi(value, "master_response_timeout", &config_errors, false);
 		/*

--- a/config.h
+++ b/config.h
@@ -62,6 +62,9 @@ typedef struct
 	char		node_name[MAXLEN];
 	char		promote_command[MAXLEN];
 	char		follow_command[MAXLEN];
+	char		stop_command[MAXLEN];
+	char		start_command[MAXLEN];
+	char		restart_command[MAXLEN];
 	char		loglevel[MAXLEN];
 	char		logfacility[MAXLEN];
 	char		rsync_options[QUERY_STR_LEN];
@@ -83,7 +86,7 @@ typedef struct
 	TablespaceList tablespace_mapping;
 }	t_configuration_options;
 
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
 
 typedef struct ErrorListCell
 {

--- a/repmgr.c
+++ b/repmgr.c
@@ -2638,9 +2638,12 @@ do_standby_follow(void)
 		exit(ERR_BAD_CONFIG);
 
 	/* Finally, restart the service */
-	maxlen_snprintf(script, "%s %s -w -D %s -m fast restart",
-					make_pg_path("pg_ctl"), options.pg_ctl_options, data_dir);
-
+	if (*options.restart_command) {
+		maxlen_snprintf(script, "%s", options.restart_command);
+	} else {
+		maxlen_snprintf(script, "%s %s -w -D %s -m fast restart",
+				make_pg_path("pg_ctl"), options.pg_ctl_options, data_dir);
+	}
 	log_notice(_("restarting server using '%s'\n"),
 			   script);
 
@@ -3110,12 +3113,15 @@ do_standby_switchover(void)
 	 *    -> use -F/--force?
 	 */
 
+	if (*options.stop_command) {
+		maxlen_snprintf(command, "%s", options.stop_command);
+	} else {
 	maxlen_snprintf(command,
 					"%s -D %s -m %s -W stop >/dev/null 2>&1 && echo 1 || echo 0",
 					make_pg_path("pg_ctl"),
 					remote_data_directory,
 					runtime_options.pg_ctl_mode);
-
+	}
 	initPQExpBuffer(&command_output);
 
 	// XXX handle failure
@@ -3824,9 +3830,13 @@ do_witness_create(void)
 
 
 	/* start new instance */
-	maxlen_snprintf(script, "%s %s -w -D %s start",
-					make_pg_path("pg_ctl"),
-					options.pg_ctl_options, runtime_options.dest_dir);
+	if (*options.start_command) {
+		maxlen_snprintf(script, "%s", options.start_command);
+	} else {
+		maxlen_snprintf(script, "%s %s -w -D %s start",
+				make_pg_path("pg_ctl"),
+				options.pg_ctl_options, runtime_options.dest_dir);
+	}
 	log_info(_("starting witness server: %s\n"), script);
 	r = system(script);
 	if (r != 0)

--- a/repmgr.conf.sample
+++ b/repmgr.conf.sample
@@ -93,6 +93,29 @@
 # (if not provided, defaults to system $PATH)
 #pg_bindir=/usr/bin/
 
+# service control commands
+#
+# repmgr provides options to to override the default pg_ctl commands
+# used to stop, start  and restart the PostgreSQL cluster
+#
+# NOTE: These commands must be runnable on remote nodes as well for switchover
+# to function correctly.
+#
+# If you use sudo, the user repmgr runs as (usually 'postgres')  must have
+# passwordless sudo access to execute the command
+#
+# For example, to use systemd, you may use the following configuration:
+#
+#    # this is required when running sudo over ssh without -t:
+#    Defaults:postgres !requiretty
+#    postgres ALL = NOPASSWD: /usr/bin/systemctl stop postgresql-9.5, \
+#       /usr/bin/systemctl start postgresql-9.5, \
+#       /usr/bin/systemctl restart postgresql-9.5
+#
+# start_command = systemctl start postgresql-9.5
+# stop_command = systemctl stop postgresql-9.5
+# restart_command = systemctl restart postgresql-9.5
+
 # external command options
 
 #rsync_options=--archive --checksum --compress --progress --rsh="ssh -o \"StrictHostKeyChecking no\""


### PR DESCRIPTION
First try at a patch that would solve issue #125 

I did some very simple testing with this, overriding the default commands to use systemctl instead, and it seems to work okay with manual failovers.

Comments?