### PR TITLE
cluster matrix, cluster diagnose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1549,8 +1549,8 @@ which contains connection details for the local database.
     These commands display connection information for each pair of
     nodes in the replication cluster.
 
-    - `cluster matrix` polls each registered server and asks it to
-      connect to each other node;
+    - `cluster matrix` runs a `cluster show` on each node and arranges
+      the results in a matrix, recording success or failure;
 
 	- `cluster diagnose` runs a `cluster matrix` on each node and
       combines the results in a single matrix.

--- a/README.md
+++ b/README.md
@@ -1544,14 +1544,20 @@ which contains connection details for the local database.
     The first column is the node's ID, and the second column represents the
     node's status (0 = master, 1 = standby, -1 = failed).
 
-* `cluster matrix`
+* `cluster matrix` and `cluster diagnose`
 
-    Displays connection information for each pair of nodes in the
-    replication cluster. This command polls each registered server and
-    asks it to connect to each other node.
+    These commands display connection information for each pair of
+    nodes in the replication cluster.
 
-    This command requires a valid `repmgr.conf` file on each node,
-    with the optional `ssh_hostname` parameter set.
+    - `cluster matrix` polls each registered server and asks it to
+      connect to each other node;
+
+	- `cluster diagnose` runs a `cluster matrix` on each node and
+      combines the results in a single matrix.
+
+    These command require a valid `repmgr.conf` file on each node, and
+    the optional `ssh_hostname` parameter must be set.
+
 
     Example 1 (all nodes up):
 
@@ -1562,6 +1568,10 @@ which contains connection details for the local database.
          node1 |  1 |  * |  * |  *
          node2 |  2 |  * |  * |  *
          node3 |  3 |  * |  * |  *
+
+    Here `cluster matrix` is sufficient to establish the state of each
+    possible connection.
+
 
     Example 2 (node1 and node2 up, node3 down):
 
@@ -1585,19 +1595,44 @@ which contains connection details for the local database.
 	node1 and node2, meaning that inbound connections to these nodes
 	have succeeded.
 
-    Example 3 (all nodes up, firewall dropping packets originating
-               from node2 and directed to port 5432 on node3)
+	In this case, `cluster diagnose` gives the same result as `cluster
+    matrix`, because from any functioning node we can observe the same
+    state: node1 and node2 are up, node3 is down.
 
-	After a long wait (same as before plus two timeouts, by default
-    one minute each), you will see the following output:
+
+    Example 3 (all nodes up, firewall dropping packets originating
+               from node1 and directed to port 5432 on node3)
+
+	Running `cluster matrix` from node1 gives the following output,
+    after a long wait (two timeouts, by default one minute each):
 
         $ repmgr -f /etc/repmgr.conf cluster matrix
 
         Name   | Id |  1 |  2 |  3
         -------+----+----+----+----
-         node1 |  1 |  * |  * |  *
-         node2 |  2 |  * |  * |  x
+         node1 |  1 |  * |  * |  x
+         node2 |  2 |  * |  * |  *
+         node3 |  3 |  ? |  ? |  ?
+
+	The matrix tells us that we cannot connect from node1 to node3,
+	and that (therefore) we don't know the state of any outbound
+	connection from node3.
+
+	In this case, the `cluster diagnose` command is more informative:
+
+        $ repmgr -f /etc/repmgr.conf cluster diagnose
+
+        Name   | Id |  1 |  2 |  3
+        -------+----+----+----+----
+         node1 |  1 |  * |  * |  x
+         node2 |  2 |  * |  * |  *
          node3 |  3 |  * |  * |  *
+
+	What happened is that `cluster diagnose` merged its own `cluster
+    matrix` with the `cluster matrix` output from node2; the latter is
+    able to connect to node3 and therefore determine the state of
+    outbound connections from that node.
+
 
 * `cluster cleanup`
 

--- a/README.md
+++ b/README.md
@@ -1544,6 +1544,61 @@ which contains connection details for the local database.
     The first column is the node's ID, and the second column represents the
     node's status (0 = master, 1 = standby, -1 = failed).
 
+* `cluster matrix`
+
+    Displays connection information for each pair of nodes in the
+    replication cluster. This command polls each registered server and
+    asks it to connect to each other node.
+
+    This command requires a valid `repmgr.conf` file on each node,
+    with the optional `ssh_hostname` parameter set.
+
+    Example 1 (all nodes up):
+
+        $ repmgr -f /etc/repmgr.conf cluster matrix
+
+        Name   | Id |  1 |  2 |  3
+        -------+----+----+----+----
+         node1 |  1 |  * |  * |  *
+         node2 |  2 |  * |  * |  *
+         node3 |  3 |  * |  * |  *
+
+    Example 2 (node1 and node2 up, node3 down):
+
+        $ repmgr -f /etc/repmgr.conf cluster matrix
+
+        Name   | Id |  1 |  2 |  3
+        -------+----+----+----+----
+         node1 |  1 |  * |  * |  x
+         node2 |  2 |  * |  * |  x
+         node3 |  3 |  ? |  ? |  ?
+
+	Each row corresponds to one server, and indicates the result of
+	testing an outbound connection from that server.
+
+	Since node3 is down, all the entries in its row are filled with
+	"?", meaning that there we cannot test outbound connections.
+
+	The other two nodes are up; the corresponding rows have "x" in the
+	column corresponding to node3, meaning that inbound connections to
+	that node have failed, and "*" in the columns corresponding to
+	node1 and node2, meaning that inbound connections to these nodes
+	have succeeded.
+
+    Example 3 (all nodes up, firewall dropping packets originating
+               from node2 and directed to port 5432 on node3)
+
+	After a long wait (same as before plus two timeouts, by default
+    one minute each), you will see the following output:
+
+        $ repmgr -f /etc/repmgr.conf cluster matrix
+
+        Name   | Id |  1 |  2 |  3
+        -------+----+----+----+----
+         node1 |  1 |  * |  * |  *
+         node2 |  2 |  * |  * |  x
+         node3 |  3 |  * |  * |  *
+
 * `cluster cleanup`
 
     Purges monitoring history from the `repl_monitor` table to prevent excessive

--- a/config.c
+++ b/config.c
@@ -217,6 +217,7 @@ parse_config(t_configuration_options *options)
 	memset(options->conninfo, 0, sizeof(options->conninfo));
 	memset(options->barman_server, 0, sizeof(options->barman_server));
 	memset(options->barman_config, 0, sizeof(options->barman_config));
+	memset(options->ssh_hostname, 0, sizeof(options->ssh_hostname));
 	options->failover = MANUAL_FAILOVER;
 	options->priority = DEFAULT_PRIORITY;
 	memset(options->node_name, 0, sizeof(options->node_name));
@@ -316,6 +317,8 @@ parse_config(t_configuration_options *options)
 			strncpy(options->barman_server, value, MAXLEN);
 		else if (strcmp(name, "barman_config") == 0)
 			strncpy(options->barman_config, value, MAXLEN);
+		else if (strcmp(name, "ssh_hostname") == 0)
+			strncpy(options->ssh_hostname, value, MAXLEN);
 		else if (strcmp(name, "rsync_options") == 0)
 			strncpy(options->rsync_options, value, QUERY_STR_LEN);
 		else if (strcmp(name, "ssh_options") == 0)
@@ -451,6 +454,10 @@ parse_config(t_configuration_options *options)
 
 		PQconninfoFree(conninfo_options);
 	}
+
+	/*
+	 * TODO: Sanity check ssh_hostname
+	 */
 
 	if (config_errors.head != NULL)
 	{
@@ -621,6 +628,10 @@ reload_config(t_configuration_options *orig_options)
 	}
 
 	/*
+	 * TODO: Sanity check the new ssh_hostname
+	 */
+
+	/*
 	 * No configuration problems detected - copy any changed values
 	 *
 	 * NB: keep these in the same order as in config.h to make it easier
@@ -645,6 +656,13 @@ reload_config(t_configuration_options *orig_options)
 	if (strcmp(orig_options->barman_server, new_options.barman_server) != 0)
 	{
 		strcpy(orig_options->barman_server, new_options.barman_server);
+		config_changed = true;
+	}
+
+	/* ssh_hostname */
+	if (strcmp(orig_options->ssh_hostname, new_options.ssh_hostname) != 0)
+	{
+		strcpy(orig_options->ssh_hostname, new_options.ssh_hostname);
 		config_changed = true;
 	}
 

--- a/config.h
+++ b/config.h
@@ -60,6 +60,7 @@ typedef struct
 	char		conninfo[MAXLEN];
 	char		barman_server[MAXLEN];
 	char		barman_config[MAXLEN];
+	char		ssh_hostname[MAXLEN];
 	int			failover;
 	int			priority;
 	char		node_name[MAXLEN];
@@ -93,7 +94,7 @@ typedef struct
  * The following will initialize the structure with a minimal set of options;
  * actual defaults are set in parse_config() before parsing the configuration file
  */
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", "", "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", "", "", "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, { NULL, NULL } }
 
 typedef struct ItemListCell
 {

--- a/dbutils.c
+++ b/dbutils.c
@@ -1224,7 +1224,7 @@ witness_copy_node_records(PGconn *masterconn, PGconn *witnessconn, char *cluster
 
 	/* Get current records from primary */
 	sqlquery_snprintf(sqlquery,
-					  "SELECT id, type, upstream_node_id, name, conninfo, priority, slot_name, active FROM %s.repl_nodes",
+					  "SELECT id, type, upstream_node_id, name, conninfo, ssh_command, priority, slot_name, active FROM %s.repl_nodes",
 					  get_repmgr_schema_quoted(masterconn));
 
 	log_verbose(LOG_DEBUG, "witness_copy_node_records():\n%s\n", sqlquery);
@@ -1260,11 +1260,12 @@ witness_copy_node_records(PGconn *masterconn, PGconn *witnessconn, char *cluster
 												 cluster_name,
 												 PQgetvalue(res, i, 3),
 												 PQgetvalue(res, i, 4),
-												 atoi(PQgetvalue(res, i, 5)),
-												 strlen(PQgetvalue(res, i, 6))
-													? PQgetvalue(res, i, 6)
+												 PQgetvalue(res, i, 5),
+												 atoi(PQgetvalue(res, i, 6)),
+												 strlen(PQgetvalue(res, i, 7))
+													? PQgetvalue(res, i, 7)
 												    : NULL,
-												 (strcmp(PQgetvalue(res, i, 7), "t") == 0)
+												 (strcmp(PQgetvalue(res, i, 8), "t") == 0)
 												 	? true
 												 	: false
 												 );
@@ -1297,7 +1298,7 @@ witness_copy_node_records(PGconn *masterconn, PGconn *witnessconn, char *cluster
  * XXX we should pass the record parameters as a struct.
  */
 bool
-create_node_record(PGconn *conn, char *action, int node, char *type, int upstream_node, char *cluster_name, char *node_name, char *conninfo, int priority, char *slot_name, bool active)
+create_node_record(PGconn *conn, char *action, int node, char *type, int upstream_node, char *cluster_name, char *node_name, char *conninfo, char *ssh_hostname, int priority, char *slot_name, bool active)
 {
 	char		sqlquery[QUERY_STR_LEN];
 	char		upstream_node_id[MAXLEN];
@@ -1338,8 +1339,9 @@ create_node_record(PGconn *conn, char *action, int node, char *type, int upstrea
 	sqlquery_snprintf(sqlquery,
 					  "INSERT INTO %s.repl_nodes "
 					  "       (id, type, upstream_node_id, cluster, "
-					  "        name, conninfo, slot_name, priority, active) "
-					  "VALUES (%i, '%s', %s, '%s', '%s', '%s', %s, %i, %s) ",
+					  "        name, conninfo, ssh_hostname, slot_name, "
+					  "        priority, active) "
+					  "VALUES (%i, '%s', %s, '%s', '%s', '%s', '%s', %s, %i, %s) ",
 					  get_repmgr_schema_quoted(conn),
 					  node,
 					  type,
@@ -1347,6 +1349,7 @@ create_node_record(PGconn *conn, char *action, int node, char *type, int upstrea
 					  cluster_name,
 					  node_name,
 					  conninfo,
+					  ssh_hostname,
 					  slot_name_buf,
 					  priority,
 					  active == true ? "TRUE" : "FALSE");
@@ -1714,7 +1717,8 @@ get_node_record(PGconn *conn, char *cluster, int node_id, t_node_info *node_info
 
 	sqlquery_snprintf(
 		sqlquery,
-		"SELECT id, type, upstream_node_id, name, conninfo, slot_name, priority, active"
+		"SELECT id, type, upstream_node_id, name, conninfo, ssh_hostname, "
+		"       slot_name, priority, active"
 		"  FROM %s.repl_nodes "
 		" WHERE cluster = '%s' "
 		"   AND id = %i",
@@ -1787,9 +1791,10 @@ _get_node_record(PGconn *conn, char *cluster, char *sqlquery, t_node_info *node_
 	node_info->upstream_node_id = atoi(PQgetvalue(res, 0, 2));
 	strncpy(node_info->name, PQgetvalue(res, 0, 3), MAXLEN);
 	strncpy(node_info->conninfo_str, PQgetvalue(res, 0, 4), MAXLEN);
-	strncpy(node_info->slot_name, PQgetvalue(res, 0, 5), MAXLEN);
-	node_info->priority = atoi(PQgetvalue(res, 0, 6));
-	node_info->active = (strcmp(PQgetvalue(res, 0, 7), "t") == 0)
+	strncpy(node_info->ssh_hostname_str, PQgetvalue(res, 0, 5), MAXLEN);
+	strncpy(node_info->slot_name, PQgetvalue(res, 0, 6), MAXLEN);
+	node_info->priority = atoi(PQgetvalue(res, 0, 7));
+	node_info->active = (strcmp(PQgetvalue(res, 0, 8), "t") == 0)
 		? true
 		: false;
 

--- a/dbutils.h
+++ b/dbutils.h
@@ -44,6 +44,7 @@ typedef struct s_node_info
 	t_server_type type;
 	char		  name[MAXLEN];
 	char		  conninfo_str[MAXLEN];
+	char		  ssh_hostname_str[MAXLEN];
 	char		  slot_name[MAXLEN];
 	int			  priority;
 	bool		  active;
@@ -57,6 +58,7 @@ typedef struct s_node_info
   NODE_NOT_FOUND, \
   NO_UPSTREAM_NODE, \
   UNKNOWN, \
+  "", \
   "", \
   "", \
   "", \
@@ -125,7 +127,7 @@ bool		start_backup(PGconn *conn, char *first_wal_segment, bool fast_checkpoint);
 bool		stop_backup(PGconn *conn, char *last_wal_segment);
 bool		set_config_bool(PGconn *conn, const char *config_param, bool state);
 bool		witness_copy_node_records(PGconn *masterconn, PGconn *witnessconn, char *cluster_name);
-bool		create_node_record(PGconn *conn, char *action, int node, char *type, int upstream_node, char *cluster_name, char *node_name, char *conninfo, int priority, char *slot_name, bool active);
+bool		create_node_record(PGconn *conn, char *action, int node, char *type, int upstream_node, char *cluster_name, char *node_name, char *conninfo, char *ssh_hostname, int priority, char *slot_name, bool active);
 bool		delete_node_record(PGconn *conn, int node, char *action);
 int			get_node_record(PGconn *conn, char *cluster, int node_id, t_node_info *node_info);
 int			get_node_record_by_name(PGconn *conn, char *cluster, const char *node_name, t_node_info *node_info);

--- a/repmgr.c
+++ b/repmgr.c
@@ -113,6 +113,7 @@ static int  get_tablespace_data_barman(char *, TablespaceDataList *);
 static char *string_skip_prefix(const char *prefix, char *string);
 static char *string_remove_trailing_newlines(char *string);
 static int  build_cluster_matrix(int **matrix, char **node_names, int *name_length);
+static int  build_cluster_diagnose(int **cube, char **node_names, int *name_length);
 
 static char *make_pg_path(char *file);
 static char *make_barman_ssh_command(void);
@@ -1277,21 +1278,17 @@ do_cluster_matrix()
 	}
 }
 
-static void
-do_cluster_diagnose(void)
+static int
+build_cluster_diagnose(int **cube, char **node_names, int *name_length)
 {
 	PGconn	   *conn;
 	PGresult   *res;
 	char		sqlquery[QUERY_STR_LEN];
-	int			i, j, k;
-	const char *node_header = "Name";
-	int			name_length = strlen(node_header);
+	int			i, j;
 
-	int			x, y, z, u, v;
+	int			x, y, z;
 	int			n = 0; /* number of nodes */
-	int		   *cube;
 	char	   *p;
-	char		c;
 
 	char		command[MAXLEN];
 	PQExpBufferData command_output;
@@ -1329,9 +1326,9 @@ do_cluster_diagnose(void)
 	 *	0 == OK
 	 */
 	n = PQntuples(res);
-	cube = (int *) pg_malloc(sizeof(int) * n * n * n);
+	*cube = (int *) pg_malloc(sizeof(int) * n * n * n);
 	for (i = 0; i < n * n * n; i++)
-		cube[i] = -2;
+		(*cube)[i] = -2;
 
 	/*
 	 * Find the maximum length of a node name
@@ -1341,9 +1338,26 @@ do_cluster_diagnose(void)
 		int name_length_cur;
 
 		name_length_cur	= strlen(PQgetvalue(res, i, 3));
-		if (name_length_cur > name_length)
-			name_length = name_length_cur;
+		if (name_length_cur > *name_length)
+			*name_length = name_length_cur;
 	}
+
+	/*
+	 * Save node names into an array
+	 */
+
+	*node_names = (char *) pg_malloc((*name_length + 1) * n);
+
+	for (i = 0; i < n; i++)
+	{
+		strncpy(*node_names + i * (*name_length + 1),
+				PQgetvalue(res, i, 3),
+				strlen(PQgetvalue(res, i, 3)) + 1);
+	}
+
+	/*
+	 * Build the connection cube
+	 */
 
 	for (i = 0; i < n; i++)
 	{
@@ -1377,7 +1391,7 @@ do_cluster_diagnose(void)
 				PQfinish(conn);
 				exit(ERR_INTERNAL);
 			}
-			cube[i * n * n + (x - 1) * n + (y - 1)] =
+			(*cube)[i * n * n + (x - 1) * n + (y - 1)] =
 				(z == -1) ? -1 : 0;
 			while (*p && (*p != '\n'))
 				p++;
@@ -1385,6 +1399,24 @@ do_cluster_diagnose(void)
 				p++;
 		}
 	}
+
+	PQclear(res);
+
+	return n;
+}
+
+static void
+do_cluster_diagnose(void)
+{
+	int			i, j, k, u, v;
+	int			n;
+	char		c;
+	char	   *node_names;
+	int		   *cube;
+	const char *node_header = "Name";
+	int			name_length = strlen(node_header);
+
+	n = build_cluster_diagnose(&cube, &node_names, &name_length);
 
 	printf("%*s | Id ", name_length, node_header);
 	for (i = 0; i < n; i++)
@@ -1401,7 +1433,7 @@ do_cluster_diagnose(void)
 	for (i = 0; i < n; i++)
 	{
 		printf("%*s | %2d ", name_length,
-			   PQgetvalue(res, i, 3), i + 1);
+			   node_names + (name_length + 1) * i, i + 1);
 		for (j = 0; j < n; j++)
 		{
 			u = cube[i * n + j];
@@ -1445,8 +1477,6 @@ do_cluster_diagnose(void)
 		}
 		printf("\n");
 	}
-
-	PQclear(res);
 }
 
 static void

--- a/repmgr.c
+++ b/repmgr.c
@@ -21,6 +21,7 @@
  * WITNESS REGISTER
  * WITNESS UNREGISTER
  *
+ * CLUSTER DIAGNOSE
  * CLUSTER MATRIX
  * CLUSTER SHOW
  * CLUSTER CLEANUP
@@ -90,6 +91,7 @@
 #define CLUSTER_SHOW		   13
 #define CLUSTER_CLEANUP		   14
 #define CLUSTER_MATRIX		   15
+#define CLUSTER_DIAGNOSE	   16
 
 static int	test_ssh_connection(char *host, char *remote_user);
 static int  copy_remote_files(char *host, char *remote_user, char *remote_path,
@@ -131,6 +133,7 @@ static void do_witness_unregister(void);
 
 static void do_cluster_show(void);
 static void do_cluster_matrix(void);
+static void do_cluster_diagnose(void);
 static void do_cluster_cleanup(void);
 static void do_check_upstream_config(void);
 static void do_help(void);
@@ -694,6 +697,8 @@ main(int argc, char **argv)
 				action = CLUSTER_SHOW;
 			else if (strcasecmp(server_cmd, "CLEANUP") == 0)
 				action = CLUSTER_CLEANUP;
+			else if (strcasecmp(server_cmd, "DIAGNOSE") == 0)
+				action = CLUSTER_DIAGNOSE;
 			else if (strcasecmp(server_cmd, "MATRIX") == 0)
 				action = CLUSTER_MATRIX;
 		}
@@ -928,6 +933,9 @@ main(int argc, char **argv)
 			break;
 		case WITNESS_UNREGISTER:
 			do_witness_unregister();
+			break;
+		case CLUSTER_DIAGNOSE:
+			do_cluster_diagnose();
 			break;
 		case CLUSTER_MATRIX:
 			do_cluster_matrix();
@@ -1234,6 +1242,178 @@ do_cluster_matrix(void)
 			}
 			printf("\n");
 		}
+	}
+
+	PQclear(res);
+}
+
+static void
+do_cluster_diagnose(void)
+{
+	PGconn	   *conn;
+	PGresult   *res;
+	char		sqlquery[QUERY_STR_LEN];
+	int			i, j, k;
+	const char *node_header = "Name";
+	int			name_length = strlen(node_header);
+
+	int			x, y, z, u, v;
+	int			n = 0; /* number of nodes */
+	int		   *cube;
+	char	   *p;
+	char		c;
+
+	char		command[MAXLEN];
+	PQExpBufferData command_output;
+
+	/* We need to connect to get the list of nodes */
+	log_info(_("connecting to database\n"));
+	conn = establish_db_connection(options.conninfo, true);
+
+	sqlquery_snprintf(sqlquery,
+			  "SELECT conninfo, ssh_hostname, type, name, upstream_node_name, id"
+			  "	 FROM %s.repl_show_nodes ORDER BY id",
+			  get_repmgr_schema_quoted(conn));
+
+	log_verbose(LOG_DEBUG, "do_cluster_show(): \n%s\n",sqlquery );
+
+	res = PQexec(conn, sqlquery);
+
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		log_err(_("Unable to retrieve node information from the database\n%s\n"),
+				PQerrorMessage(conn));
+		log_hint(_("Please check that all nodes have been registered\n"));
+
+		PQclear(res);
+		PQfinish(conn);
+		exit(ERR_BAD_CONFIG);
+	}
+	PQfinish(conn);
+
+	/*
+	 * Allocate an empty cube matrix
+	 *
+	 * -2 == NULL
+	 * -1 == Error
+	 *	0 == OK
+	 */
+	n = PQntuples(res);
+	cube = (int *) pg_malloc(sizeof(int) * n * n * n);
+	for (i = 0; i < n * n * n; i++)
+		cube[i] = -2;
+
+	/*
+	 * Find the maximum length of a node name
+	 */
+	for (i = 0; i < n; i++)
+	{
+		int name_length_cur;
+
+		name_length_cur	= strlen(PQgetvalue(res, i, 3));
+		if (name_length_cur > name_length)
+			name_length = name_length_cur;
+	}
+
+	for (i = 0; i < n; i++)
+	{
+		maxlen_snprintf(command,
+						"repmgr cluster matrix --csv");
+
+		initPQExpBuffer(&command_output);
+
+		if (i + 1 == options.node)
+		{
+			(void)local_command(
+				command,
+				&command_output);
+		}
+		else
+		{
+			(void)remote_command(
+				PQgetvalue(res, i, 1),
+				"postgres",
+				command,
+				&command_output);
+		}
+
+		p = command_output.data;
+
+		for (j = 0; j < n * n; j++)
+		{
+			if (sscanf(p, "%d,%d,%d", &x, &y, &z) != 3)
+			{
+				fprintf(stderr, _("cannot parse --csv output: %s\n"), p);
+				PQfinish(conn);
+				exit(ERR_INTERNAL);
+			}
+			cube[i * n * n + (x - 1) * n + (y - 1)] =
+				(z == -1) ? -1 : 0;
+			while (*p && (*p != '\n'))
+				p++;
+			if (*p == '\n')
+				p++;
+		}
+	}
+
+	printf("%*s | Id ", name_length, node_header);
+	for (i = 0; i < n; i++)
+		printf("| %2d ", i+1);
+	printf("\n");
+
+	for (i = 0; i < name_length; i++)
+		printf("-");
+	printf("-+----");
+	for (i = 0; i < n; i++)
+		printf("+----");
+	printf("\n");
+
+	for (i = 0; i < n; i++)
+	{
+		printf("%*s | %2d ", name_length,
+			   PQgetvalue(res, i, 3), i + 1);
+		for (j = 0; j < n; j++)
+		{
+			u = cube[i * n + j];
+			for (k = 1; k < n; k++)
+			{
+				/*
+				 * The value of entry (i,j) is equal to the
+				 * maximum value of all the (i,j,k). Indeed:
+				 *
+				 * - if one of the (i,j,k) is 0 (node up), then 0
+				 *	 (the node is up);
+				 *
+				 * - if the (i,j,k) are either -1 (down) or -2
+				 *	 (unknown), then -1 (the node is down);
+				 *
+				 * - if all the (i,j,k) are -2 (unknown), then -2
+				 *	 (the node is in an unknown state).
+				 */
+
+				v = cube[k * n * n + i * n + j];
+
+				if (v > u) u = v;
+			}
+
+			switch (u)
+			{
+			case -2:
+				c = '?';
+				break;
+			case -1:
+				c = 'x';
+				break;
+			case 0:
+				c = '*';
+				break;
+			default:
+				exit(ERR_INTERNAL);
+			}
+
+			printf("|  %c ", c);
+		}
+		printf("\n");
 	}
 
 	PQclear(res);

--- a/repmgr.c
+++ b/repmgr.c
@@ -1092,7 +1092,7 @@ do_cluster_matrix(void)
 
 	sqlquery_snprintf(sqlquery,
 			  "SELECT conninfo, ssh_hostname, type, name, upstream_node_name, id"
-			  "  FROM %s.repl_show_nodes",
+			  "  FROM %s.repl_show_nodes ORDER BY id",
 			  get_repmgr_schema_quoted(conn));
 
 	log_verbose(LOG_DEBUG, "do_cluster_show(): \n%s\n",sqlquery );

--- a/repmgr.c
+++ b/repmgr.c
@@ -898,6 +898,20 @@ main(int argc, char **argv)
 		log_verbose(LOG_DEBUG, "slot name initialised as: %s\n", repmgr_slot_name);
 	}
 
+	if (action == CLUSTER_MATRIX && (! strlen(options.ssh_hostname)))
+	{
+		log_err(_("CLUSTER MATRIX requires ssh_hostname.\n"
+				  "Please ensure ssh_hostname is set in the configuration file.\n"));
+		exit(ERR_BAD_CONFIG);
+	}
+
+	if (action == CLUSTER_DIAGNOSE && (! strlen(options.ssh_hostname)))
+	{
+		log_err(_("CLUSTER DIAGNOSE requires ssh_hostname.\n"
+				  "Please ensure ssh_hostname is set in the configuration file.\n"));
+		exit(ERR_BAD_CONFIG);
+	}
+
 	switch (action)
 	{
 		case MASTER_REGISTER:

--- a/repmgr.c
+++ b/repmgr.c
@@ -112,6 +112,7 @@ static int  get_tablespace_data_barman(char *, TablespaceDataList *);
 
 static char *string_skip_prefix(const char *prefix, char *string);
 static char *string_remove_trailing_newlines(char *string);
+static int  build_cluster_matrix(int **matrix, char **node_names, int *name_length);
 
 static char *make_pg_path(char *file);
 static char *make_barman_ssh_command(void);
@@ -1076,19 +1077,16 @@ do_cluster_show(void)
 	PQclear(res);
 }
 
-static void
-do_cluster_matrix(void)
+static int
+build_cluster_matrix(int **matrix, char **node_names, int *name_length)
 {
 	PGconn	   *conn;
 	PGresult   *res;
 	char		sqlquery[QUERY_STR_LEN];
 	int			i, j;
-	const char *node_header = "Name";
-	int			name_length = strlen(node_header);
+	int			n;
 
 	int         x, y;
-	int         n = 0; /* number of nodes */
-	int        *matrix;
 	char       *p;
 
 	char	    command[MAXLEN];
@@ -1127,9 +1125,9 @@ do_cluster_matrix(void)
 	 *  0 == OK
 	 */
 	n = PQntuples(res);
-	matrix = (int *) pg_malloc(sizeof(int) * n * n);
+	*matrix = (int *) pg_malloc(sizeof(int) * n * n);
 	for (i = 0; i < n * n; i++)
-		matrix[i] = -2;
+		(*matrix)[i] = -2;
 
 	/*
 	 * Find the maximum length of a node name
@@ -1139,9 +1137,26 @@ do_cluster_matrix(void)
 		int name_length_cur;
 
 		name_length_cur	= strlen(PQgetvalue(res, i, 3));
-		if (name_length_cur > name_length)
-			name_length = name_length_cur;
+		if (name_length_cur > *name_length)
+			*name_length = name_length_cur;
 	}
+
+	/*
+	 * Save node names into an array
+	 */
+
+	*node_names = (char *) pg_malloc((*name_length + 1) * n);
+
+	for (i = 0; i < n; i++)
+	{
+		strncpy(*node_names + i * (*name_length + 1),
+				PQgetvalue(res, i, 3),
+				strlen(PQgetvalue(res, i, 3)) + 1);
+	}
+
+	/*
+	 * Build the connection matrix
+	 */
 
 	for (i = 0; i < n; i++)
 	{
@@ -1152,7 +1167,7 @@ do_cluster_matrix(void)
 		connection_status =
 			(PQstatus(conn) == CONNECTION_OK) ? 0 : -1;
 
-		matrix[(options.node - 1) * n + i] =
+		(*matrix)[(options.node - 1) * n + i] =
 			connection_status;
 
 		if (connection_status)
@@ -1182,7 +1197,7 @@ do_cluster_matrix(void)
 				PQfinish(conn);
 				exit(ERR_INTERNAL);
 			}
-			matrix[i * n + (x - 1)] =
+			(*matrix)[i * n + (x - 1)] =
 				(y == -1) ? -1 : 0;
 			while (*p && (*p != '\n'))
 				p++;
@@ -1192,6 +1207,23 @@ do_cluster_matrix(void)
 
 		PQfinish(conn);
 	}
+
+	PQclear(res);
+
+	return n;
+}
+
+static void
+do_cluster_matrix()
+{
+	int			i, j;
+	int			n;
+	char	   *node_names;
+	int		   *matrix;
+	const char *node_header = "Name";
+	int			name_length = strlen(node_header);
+
+	n = build_cluster_matrix(&matrix, &node_names, &name_length);
 
 	if (runtime_options.csv_mode)
 	{
@@ -1220,7 +1252,7 @@ do_cluster_matrix(void)
 		for (i = 0; i < n; i++)
 		{
 			printf("%*s | %2d ", name_length,
-				   PQgetvalue(res, i, 3), i + 1);
+				   node_names + (name_length + 1) * i, i + 1);
 			for (j = 0; j < n; j++)
 			{
 				switch (matrix[i * n + j])
@@ -1243,8 +1275,6 @@ do_cluster_matrix(void)
 			printf("\n");
 		}
 	}
-
-	PQclear(res);
 }
 
 static void

--- a/repmgr.c
+++ b/repmgr.c
@@ -21,6 +21,7 @@
  * WITNESS REGISTER
  * WITNESS UNREGISTER
  *
+ * CLUSTER MATRIX
  * CLUSTER SHOW
  * CLUSTER CLEANUP
  *
@@ -88,7 +89,7 @@
 #define WITNESS_UNREGISTER     12
 #define CLUSTER_SHOW		   13
 #define CLUSTER_CLEANUP		   14
-
+#define CLUSTER_MATRIX		   15
 
 static int	test_ssh_connection(char *host, char *remote_user);
 static int  copy_remote_files(char *host, char *remote_user, char *remote_path,
@@ -129,6 +130,7 @@ static void do_witness_register(PGconn *masterconn);
 static void do_witness_unregister(void);
 
 static void do_cluster_show(void);
+static void do_cluster_matrix(void);
 static void do_cluster_cleanup(void);
 static void do_check_upstream_config(void);
 static void do_help(void);
@@ -692,6 +694,8 @@ main(int argc, char **argv)
 				action = CLUSTER_SHOW;
 			else if (strcasecmp(server_cmd, "CLEANUP") == 0)
 				action = CLUSTER_CLEANUP;
+			else if (strcasecmp(server_cmd, "MATRIX") == 0)
+				action = CLUSTER_MATRIX;
 		}
 		else if (strcasecmp(server_mode, "WITNESS") == 0)
 		{
@@ -925,6 +929,9 @@ main(int argc, char **argv)
 		case WITNESS_UNREGISTER:
 			do_witness_unregister();
 			break;
+		case CLUSTER_MATRIX:
+			do_cluster_matrix();
+			break;
 		case CLUSTER_SHOW:
 			do_cluster_show();
 			break;
@@ -1045,8 +1052,7 @@ do_cluster_show(void)
 		if (runtime_options.csv_mode)
 		{
 			int connection_status =
-				(PQstatus(conn) == CONNECTION_OK) ?
-				(is_standby(conn) ? 1 : 0) : -1;
+				(PQstatus(conn) == CONNECTION_OK) ? 0 : -1;
 			printf("%s,%d\n", PQgetvalue(res, i, 4), connection_status);
 		}
 		else
@@ -1057,6 +1063,177 @@ do_cluster_show(void)
 			printf("| %s\n", PQgetvalue(res, i, 0));
 		}
 		PQfinish(conn);
+	}
+
+	PQclear(res);
+}
+
+static void
+do_cluster_matrix(void)
+{
+	PGconn	   *conn;
+	PGresult   *res;
+	char		sqlquery[QUERY_STR_LEN];
+	int			i, j;
+	const char *node_header = "Name";
+	int			name_length = strlen(node_header);
+
+	int         x, y;
+	int         n = 0; /* number of nodes */
+	int        *matrix;
+	char       *p;
+
+	char	    command[MAXLEN];
+	PQExpBufferData command_output;
+
+	/* We need to connect to get the list of nodes */
+	log_info(_("connecting to database\n"));
+	conn = establish_db_connection(options.conninfo, true);
+
+	sqlquery_snprintf(sqlquery,
+			  "SELECT conninfo, ssh_hostname, type, name, upstream_node_name, id"
+			  "  FROM %s.repl_show_nodes",
+			  get_repmgr_schema_quoted(conn));
+
+	log_verbose(LOG_DEBUG, "do_cluster_show(): \n%s\n",sqlquery );
+
+	res = PQexec(conn, sqlquery);
+
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		log_err(_("Unable to retrieve node information from the database\n%s\n"),
+				PQerrorMessage(conn));
+		log_hint(_("Please check that all nodes have been registered\n"));
+
+		PQclear(res);
+		PQfinish(conn);
+		exit(ERR_BAD_CONFIG);
+	}
+	PQfinish(conn);
+
+	/*
+	 * Allocate an empty matrix
+	 *
+	 * -2 == NULL
+	 * -1 == Error
+	 *  0 == OK
+	 */
+	n = PQntuples(res);
+	matrix = (int *) pg_malloc(sizeof(int) * n * n);
+	for (i = 0; i < n * n; i++)
+		matrix[i] = -2;
+
+	/*
+	 * Find the maximum length of a node name
+	 */
+	for (i = 0; i < n; i++)
+	{
+		int name_length_cur;
+
+		name_length_cur	= strlen(PQgetvalue(res, i, 3));
+		if (name_length_cur > name_length)
+			name_length = name_length_cur;
+	}
+
+	for (i = 0; i < n; i++)
+	{
+		int connection_status;
+
+		conn = establish_db_connection(PQgetvalue(res, i, 0), false);
+
+		connection_status =
+			(PQstatus(conn) == CONNECTION_OK) ? 0 : -1;
+
+		matrix[(options.node - 1) * n + i] =
+			connection_status;
+
+		if (connection_status)
+			continue;
+
+		if (i + 1 == options.node)
+			continue;
+
+		maxlen_snprintf(command,
+						"repmgr cluster show --csv");
+
+		initPQExpBuffer(&command_output);
+
+		(void)remote_command(
+			PQgetvalue(res, i, 1),
+			"postgres",
+			command,
+			&command_output);
+
+		p = command_output.data;
+
+		for (j = 0; j < n; j++)
+		{
+			if (sscanf(p, "%d,%d", &x, &y) != 2)
+			{
+				fprintf(stderr, _("cannot parse --csv output: %s\n"), p);
+				PQfinish(conn);
+				exit(ERR_INTERNAL);
+			}
+			matrix[i * n + (x - 1)] =
+				(y == -1) ? -1 : 0;
+			while (*p && (*p != '\n'))
+				p++;
+			if (*p == '\n')
+				p++;
+		}
+
+		PQfinish(conn);
+	}
+
+	if (runtime_options.csv_mode)
+	{
+		for (i = 0; i < n; i++)
+			for (j = 0; j < n; j++)
+				printf("%d,%d,%d\n",
+					   i + 1, j + 1,
+					   matrix[i * n + j]);
+	}
+	else
+	{
+		char c;
+
+		printf("%*s | Id ", name_length, node_header);
+		for (i = 0; i < n; i++)
+			printf("| %2d ", i+1);
+		printf("\n");
+
+		for (i = 0; i < name_length; i++)
+			printf("-");
+		printf("-+----");
+		for (i = 0; i < n; i++)
+			printf("+----");
+		printf("\n");
+
+		for (i = 0; i < n; i++)
+		{
+			printf("%*s | %2d ", name_length,
+				   PQgetvalue(res, i, 3), i + 1);
+			for (j = 0; j < n; j++)
+			{
+				switch (matrix[i * n + j])
+				{
+				case -2:
+					c = '?';
+					break;
+				case -1:
+					c = 'x';
+					break;
+				case 0:
+					c = '*';
+					break;
+				default:
+					exit(ERR_INTERNAL);
+				}
+
+				printf("|  %c ", c);
+			}
+			printf("\n");
+		}
 	}
 
 	PQclear(res);
@@ -1284,6 +1461,7 @@ do_master_register(void)
 										options.cluster_name,
 										options.node_name,
 										options.conninfo,
+										options.ssh_hostname,
 										options.priority,
 										repmgr_slot_name_ptr,
 										true);
@@ -1409,6 +1587,7 @@ do_standby_register(void)
 										options.cluster_name,
 										options.node_name,
 										options.conninfo,
+										options.ssh_hostname,
 										options.priority,
 										repmgr_slot_name_ptr,
 										true);
@@ -4858,6 +5037,7 @@ do_witness_register(PGconn *masterconn)
 										options.cluster_name,
 										options.node_name,
 										options.conninfo,
+										options.ssh_hostname,
 										options.priority,
 										NULL,
 										true);
@@ -5082,7 +5262,8 @@ do_help(void)
 	printf(_("  --pg_rewind[=VALUE]                 (standby switchover) 9.3/9.4 only - use pg_rewind if available,\n" \
 			 "                                        optionally providing a path to the binary\n"));
 	printf(_("  -k, --keep-history=VALUE            (cluster cleanup) retain indicated number of days of history (default: 0)\n"));
-	printf(_("  --csv                               (cluster show) output in CSV mode (0 = master, 1 = standby, -1 = down)\n"));
+	printf(_("  --csv                               (cluster show, cluster matrix) output in CSV mode:\n" \
+			 "                                        0 = OK, -1 = down, -2 = unknown\n"));
 	printf(_("  -P, --pwprompt                      (witness server) prompt for password when creating users\n"));
 	printf(_("  -S, --superuser=USERNAME            (witness server) superuser username for witness database\n" \
 			 "                                        (default: postgres)\n"));
@@ -5101,6 +5282,7 @@ do_help(void)
 	printf(_(" witness register      - registers a witness server\n"));
 	printf(_(" witness unregister    - unregisters a witness server\n"));
 	printf(_(" cluster show          - displays information about cluster nodes\n"));
+	printf(_(" cluster matrix        - displays the cluster's connection matrix\n"));
 	printf(_(" cluster cleanup       - prunes or truncates monitoring history\n" \
 			 "                         (monitoring history creation requires repmgrd\n" \
 			 "                         with --monitoring-history option)\n"));
@@ -5678,12 +5860,12 @@ check_parameters_for_action(const int action)
 		}
 	}
 
-    /* Warn about parameters which apply to CLUSTER SHOW only */
-	if (action != CLUSTER_SHOW)
+    /* Warn about parameters which apply only to CLUSTER SHOW and CLUSTER MATRIX */
+	if (action != CLUSTER_SHOW && action != CLUSTER_MATRIX)
 	{
 		if (runtime_options.csv_mode)
 		{
-			item_list_append(&cli_warnings, _("--csv can only be used when executing CLUSTER SHOW"));
+			item_list_append(&cli_warnings, _("--csv can only be used when executing CLUSTER SHOW or CLUSTER MATRIX"));
 		}
 	}
 
@@ -5775,6 +5957,7 @@ create_schema(PGconn *conn)
 					  "  cluster          TEXT    NOT NULL, "
 					  "  name             TEXT    NOT NULL, "
 					  "  conninfo         TEXT    NOT NULL, "
+					  "  ssh_hostname     TEXT    NULL, "
 					  "  slot_name        TEXT    NULL, "
 					  "  priority         INTEGER NOT NULL, "
 					  "  active           BOOLEAN NOT NULL DEFAULT TRUE )",
@@ -5910,7 +6093,8 @@ create_schema(PGconn *conn)
 	/* CREATE VIEW repl_show_nodes  */
 	sqlquery_snprintf(sqlquery,
 					  "CREATE VIEW %s.repl_show_nodes AS "
-			                  "SELECT rn.id, rn.conninfo, rn.type, rn.name, rn.cluster,"
+			                  "SELECT rn.id, rn.conninfo, rn.ssh_hostname, "
+					          "  rn.type, rn.name, rn.cluster,"
 			                  "  rn.priority, rn.active, sq.name AS upstream_node_name"
 			                  "  FROM %s.repl_nodes as rn"
 			                  "  LEFT JOIN %s.repl_nodes AS sq"

--- a/repmgr.conf.sample
+++ b/repmgr.conf.sample
@@ -42,6 +42,12 @@
 # Optional configuration items
 # ============================
 
+# SSH connection information
+# We recommend using the "postgres" user, so it is enough to indicate the hostname.
+# If extra parameters such as port, etc. are needed, they can be
+# specified in the .ssh/config file.
+#ssh_hostname='192.168.204.104'
+
 # Replication settings
 # ---------------------
 

--- a/repmgr.sql
+++ b/repmgr.sql
@@ -17,6 +17,7 @@ CREATE TABLE repl_nodes (
   cluster   	text    not null,       -- Name to identify the cluster
   name			text	not null,
   conninfo      text    not null,
+  ssh_command   text,
   priority  	integer not null,
   witness   	boolean not null default false
 );
@@ -65,6 +66,6 @@ CREATE INDEX idx_repl_status_sort ON repl_monitor(last_monitor_time, standby_nod
  * in each case (when appliable)
  */
 CREATE VIEW repl_show_nodes AS 
-SELECT rn.id, rn.conninfo, rn.type, rn.name, rn.cluster,
+SELECT rn.id, rn.conninfo, rn.ssh_command, rn.type, rn.name, rn.cluster,
 	rn.priority, rn.active, sq.name AS upstream_node_name
 FROM repl_nodes as rn LEFT JOIN repl_nodes AS sq ON sq.id=rn.upstream_node_id;

--- a/sql/repmgr3.1.3_repmgr3.1.4.sql
+++ b/sql/repmgr3.1.3_repmgr3.1.4.sql
@@ -1,0 +1,30 @@
+/*
+ * Update a repmgr 3.1.3 installation to repmgr 3.1.4
+ * --------------------------------------------------
+ *
+ * The new repmgr package should be installed first. Then
+ * carry out these steps:
+ * 
+ *   1. On the master node, execute the SQL statements listed below;
+ * 
+ *   2. (optional, recommended) add the ssh_hostname parameter to
+ *      repmgr.conf, and update the repl_nodes table accordingly
+ */
+
+/*
+ * If your repmgr installation is not included in your repmgr
+ * user's search path, please set the search path to the name
+ * of the repmgr schema to ensure objects are installed in
+ * the correct location.
+ *
+ * The repmgr schema is  "repmgr_" + the cluster name defined in
+ * 'repmgr.conf'.
+ */
+
+-- SET search_path TO 'name_of_repmgr_schema';
+
+BEGIN;
+
+ALTER TABLE repl_nodes ADD COLUMN ssh_hostname text;
+
+COMMIT;


### PR DESCRIPTION
This branch introduces `cluster matrix` and `cluster diagnose` commands, which display connection information for each pair of nodes in the replication cluster.
- `cluster matrix` polls each registered server and asks it to connect to each other node;
- `cluster diagnose` runs a `cluster matrix` on each node and combines the results in a single matrix.
  More details and examples can be found in README.md
  (unfortunately Github doesn't support links to specific lines of this file)
