### PR TITLE
Barman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ ensure that:
 - the `barman_server` setting in `repmgr.conf` is set to the SSH
   hostname of the Barman server;
 - the `pg_restore_command` setting in `repmgr.conf` is configured to
-  use a copy of the `barman-wal-restore` script shipped with Barman
+  use a copy of the `barman-wal-restore.py` script shipped with Barman
   (see below);
 - the Barman catalogue includes at least one valid backup for this
   server.
@@ -546,7 +546,7 @@ ensure that:
 > corresponding to the value of `barman_server` in `repmgr.conf`. See
 > the "Host" section in `man 5 ssh_config` for more details.
 
-`barman-wal-restore` is a short shell script provided by the Barman
+`barman-wal-restore.py` is a Python script provided by the Barman
 development team, which must be copied in a location accessible to
 `repmgr`, and marked as executable; `pg_restore_command` must then be
 set as follows:
@@ -554,16 +554,16 @@ set as follows:
     <script> <Barman hostname> <cluster_name> %f %p 
 
 For instance, suppose that we have installed Barman on the `barmansrv`
-host, and that we have placed a copy of `barman-wal-restore` into the
-`/usr/local/bin` directory. First, we ensure that the script is
+host, and that we have placed a copy of `barman-wal-restore.py` into
+the `/usr/local/bin` directory. First, we ensure that the script is
 executable:
 
-    sudo chmod +x /usr/local/bin/barman-wal-restore
+    sudo chmod +x /usr/local/bin/barman-wal-restore.py
 
 Then we check that `repmgr.conf` includes the following lines:
 
 	barman_server=barmansrv
-	pg_restore_command=/usr/local/bin/barman-wal-restore barmansrv test %f %p
+	pg_restore_command=/usr/local/bin/barman-wal-restore.py barmansrv test %f %p
 
 Now we can clone a standby using the Barman server:
 
@@ -610,6 +610,10 @@ the required files are copied. This results in additional I/O on both source
 and destination server as the contents of files existing on both servers need
 to be compared, meaning this method is not necessarily faster than making a
 fresh clone with `pg_basebackup`.
+
+> *NOTE*: `barman-wal-restore.py` supports command line switches to
+> control parallelism (`--parallel=N`) and compression (`--bzip2`,
+> `--gzip`).
 
 ### Dealing with PostgreSQL configuration files
 

--- a/README.md
+++ b/README.md
@@ -504,6 +504,76 @@ standby's upstream server is the replication cluster master. While of limited
 use in a simple master/standby replication cluster, this information is required
 to effectively manage cascading replication (see below).
 
+### Using Barman to clone a standby
+
+`repmgr standby clone` also supports Barman, the Backup and
+Replication manager (http://www.pgbarman.org/), as a provider of both
+base backups and WAL files.
+
+Barman support provides the following advantages:
+
+- the primary node does not need to perform a new backup every time a
+  new standby is cloned;
+- a standby node can be disconnected for longer periods without losing
+  the ability to catch up, and without causing accumulation of WAL
+  files on the primary node;
+- therefore, `repmgr` does not need to use replication slots, and the
+  primary node does not need to set `wal_keep_segments`.
+
+> *NOTE*: In view of the above, Barman support is incompatible with
+> the `use_replication_slots` setting in `repmgr.conf`.
+
+In order to enable Barman support for `repmgr standby clone`, you must
+ensure that:
+
+- the name of the server configured in Barman is equal to the
+  `cluster_name` setting in `repmgr.conf`;
+- the `barman_server` setting in `repmgr.conf` is set to the SSH
+  hostname of the Barman server;
+- the `pg_restore_command` setting in `repmgr.conf` is configured to
+  use a copy of the `barman-wal-restore` script shipped with Barman
+  (see below);
+- the Barman catalogue includes at least one valid backup for this
+  server.
+
+> *NOTE*: Barman support is automatically enabled if `barman_server`
+> is set. Normally this is a good practice; however, the command line
+> option `--without-barman` can be used to disable it.
+
+> *NOTE*: if you have a non-default SSH configuration on the Barman
+> server, e.g. using a port other than 22, then you can set those
+> parameters in a dedicated Host section in `~/.ssh/config`
+> corresponding to the value of `barman_server` in `repmgr.conf`. See
+> the "Host" section in `man 5 ssh_config` for more details.
+
+`barman-wal-restore` is a short shell script provided by the Barman
+development team, which must be copied in a location accessible to
+`repmgr`, and marked as executable; `pg_restore_command` must then be
+set as follows:
+
+    <script> <Barman hostname> <cluster_name> %f %p 
+
+For instance, suppose that we have installed Barman on the `barmansrv`
+host, and that we have placed a copy of `barman-wal-restore` into the
+`/usr/local/bin` directory. First, we ensure that the script is
+executable:
+
+    sudo chmod +x /usr/local/bin/barman-wal-restore
+
+Then we check that `repmgr.conf` includes the following lines:
+
+	barman_server=barmansrv
+	pg_restore_command=/usr/local/bin/barman-wal-restore barmansrv test %f %p
+
+Now we can clone a standby using the Barman server:
+
+    $ repmgr -h node1 -D 9.5/main -f /etc/repmgr.conf standby clone
+    [2016-06-12 20:08:35] [NOTICE] destination directory '9.5/main' provided
+    [2016-06-12 20:08:35] [NOTICE] getting backup from Barman...
+    [2016-06-12 20:08:36] [NOTICE] standby clone (from Barman) complete
+    [2016-06-12 20:08:36] [NOTICE] you can now start your PostgreSQL server
+    [2016-06-12 20:08:36] [HINT] for example : pg_ctl -D 9.5/data start
+    [2016-06-12 20:08:36] [HINT] After starting the server, you need to register this standby with "repmgr standby register"
 
 Advanced options for cloning a standby
 --------------------------------------

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ ensure that:
   `cluster_name` setting in `repmgr.conf`;
 - the `barman_server` setting in `repmgr.conf` is set to the SSH
   hostname of the Barman server;
-- the `pg_restore_command` setting in `repmgr.conf` is configured to
+- the `restore_command` setting in `repmgr.conf` is configured to
   use a copy of the `barman-wal-restore.py` script shipped with Barman
   (see below);
 - the Barman catalogue includes at least one valid backup for this
@@ -548,8 +548,8 @@ ensure that:
 
 `barman-wal-restore.py` is a Python script provided by the Barman
 development team, which must be copied in a location accessible to
-`repmgr`, and marked as executable; `pg_restore_command` must then be
-set as follows:
+`repmgr`, and marked as executable; `restore_command` must then be
+set in `repmgr.conf` as follows:
 
     <script> <Barman hostname> <cluster_name> %f %p 
 
@@ -563,7 +563,7 @@ executable:
 Then we check that `repmgr.conf` includes the following lines:
 
 	barman_server=barmansrv
-	pg_restore_command=/usr/local/bin/barman-wal-restore.py barmansrv test %f %p
+	restore_command=/usr/local/bin/barman-wal-restore.py barmansrv test %f %p
 
 Now we can clone a standby using the Barman server:
 

--- a/README.md
+++ b/README.md
@@ -537,8 +537,10 @@ ensure that:
   server.
 
 > *NOTE*: Barman support is automatically enabled if `barman_server`
-> is set. Normally this is a good practice; however, the command line
-> option `--without-barman` can be used to disable it.
+> is set. Normally it is a good practice to use Barman, for instance
+> when fetching a base backup while cloning a standby; in any case,
+> Barman mode can be disabled using the `--without-barman` command
+> line option.
 
 > *NOTE*: if you have a non-default SSH configuration on the Barman
 > server, e.g. using a port other than 22, then you can set those

--- a/config.c
+++ b/config.c
@@ -215,6 +215,7 @@ parse_config(t_configuration_options *options)
 	options->upstream_node = NO_UPSTREAM_NODE;
 	options->use_replication_slots = 0;
 	memset(options->conninfo, 0, sizeof(options->conninfo));
+	memset(options->barman_server, 0, sizeof(options->barman_server));
 	options->failover = MANUAL_FAILOVER;
 	options->priority = DEFAULT_PRIORITY;
 	memset(options->node_name, 0, sizeof(options->node_name));
@@ -310,6 +311,8 @@ parse_config(t_configuration_options *options)
 			options->upstream_node = repmgr_atoi(value, "upstream_node", &config_errors, false);
 		else if (strcmp(name, "conninfo") == 0)
 			strncpy(options->conninfo, value, MAXLEN);
+		else if (strcmp(name, "barman_server") == 0)
+			strncpy(options->barman_server, value, MAXLEN);
 		else if (strcmp(name, "rsync_options") == 0)
 			strncpy(options->rsync_options, value, QUERY_STR_LEN);
 		else if (strcmp(name, "ssh_options") == 0)
@@ -632,6 +635,13 @@ reload_config(t_configuration_options *orig_options)
 	if (strcmp(orig_options->conninfo, new_options.conninfo) != 0)
 	{
 		strcpy(orig_options->conninfo, new_options.conninfo);
+		config_changed = true;
+	}
+
+	/* barman_server */
+	if (strcmp(orig_options->barman_server, new_options.barman_server) != 0)
+	{
+		strcpy(orig_options->barman_server, new_options.barman_server);
 		config_changed = true;
 	}
 

--- a/config.h
+++ b/config.h
@@ -58,6 +58,7 @@ typedef struct
 	int			node;
 	int         upstream_node;
 	char		conninfo[MAXLEN];
+	char		barman_server[MAXLEN];
 	int			failover;
 	int			priority;
 	char		node_name[MAXLEN];
@@ -91,7 +92,7 @@ typedef struct
  * The following will initialize the structure with a minimal set of options;
  * actual defaults are set in parse_config() before parsing the configuration file
  */
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", -1, NO_UPSTREAM_NODE, "", "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, {NULL, NULL} }
 
 typedef struct ItemListCell
 {

--- a/config.h
+++ b/config.h
@@ -105,6 +105,22 @@ typedef struct ItemList
 	ItemListCell *tail;
 } ItemList;
 
+typedef struct TablespaceDataListCell
+{
+	struct TablespaceDataListCell *next;
+	char	   *name;
+	char	   *oid;
+	char	   *location;
+	/* optional payload */
+	FILE       *f;
+} TablespaceDataListCell;
+
+typedef struct TablespaceDataList
+{
+	TablespaceDataListCell *head;
+	TablespaceDataListCell *tail;
+} TablespaceDataList;
+
 void set_progname(const char *argv0);
 const char * progname(void);
 

--- a/repmgr.c
+++ b/repmgr.c
@@ -1628,6 +1628,7 @@ get_tablespace_data_barman
 	tablespace_list->tail = NULL;
 
 	p = string_skip_prefix("[", p);
+	if (p == NULL) return -1;
 
 	while (*p == '(')
 	{
@@ -2187,7 +2188,7 @@ do_standby_clone(void)
 						while (fgets(buf, MAXLEN, fi2) != NULL)
 						{
 							q = string_skip_prefix("tablespaces=", buf);
-							if (q != NULL)
+							if (q != NULL && strncmp(q, "None\n", 5))
 							{
 								get_tablespace_data_barman
 									(q, &tablespace_list);
@@ -2294,14 +2295,14 @@ do_standby_clone(void)
 					/* Only from 9.5 */
 					"pg_commit_ts",
 					/* Only from 9.4 */
-					"pg_dynshmem", "pg_logical",
+					"pg_dynshmem", "pg_logical", "pg_replslot",
 					/* Already in 9.3 */
 					"pg_serial", "pg_snapshots", "pg_stat", "pg_stat_tmp", "pg_tblspc",
 					"pg_twophase", "pg_xlog", 0
 				};
 				const int vers[] = {
 					90500,
-					90400, 90400,
+					90400, 90400, 90400,
 					0, 0, 0, 0, 0,
 					0, 0, 0
 				};

--- a/repmgr.h
+++ b/repmgr.h
@@ -56,6 +56,7 @@
 #define OPT_PWPROMPT                     7
 #define OPT_CSV                          8
 #define OPT_NODE                         9
+#define OPT_WITHOUT_BARMAN               10
 
 
 /* Run time options type */
@@ -79,6 +80,7 @@ typedef struct
 	bool		fast_checkpoint;
 	bool		ignore_external_config_files;
 	bool		csv_mode;
+	bool		without_barman;
 	char		masterport[MAXLEN];
 	/*
 	 * configuration file parameters which can be overridden on the
@@ -102,7 +104,7 @@ typedef struct
 	char		recovery_min_apply_delay[MAXLEN];
 }	t_runtime_options;
 
-#define T_RUNTIME_OPTIONS_INITIALIZER { "", "", "", "", "", "", "", DEFAULT_WAL_KEEP_SEGMENTS, false, false, false, false, false, false, false, false, false, false, "", "", "", "", "fast", "", 0, 0, "", ""}
+#define T_RUNTIME_OPTIONS_INITIALIZER { "", "", "", "", "", "", "", DEFAULT_WAL_KEEP_SEGMENTS, false, false, false, false, false, false, false, false, false, false, false, "", "", "", "", "fast", "", 0, 0, "", ""}
 
 struct BackupLabel
 {


### PR DESCRIPTION
In this branch we add Barman support to `repmgr standby clone`.
Barman will provide both base backups and WAL files. In particular:
- the primary node does not need to perform a new backup every time a new standby is cloned;
- a standby node can be disconnected for longer periods without losing the ability to catch up, and without causing accumulation of WAL files on the primary node;
- the primary node does not require `wal_keep_segments`
- Barman mode cannot be used together with replication slots
