### PR TITLE
Fix for #167

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -3526,7 +3526,7 @@ do_standby_switchover(void)
 		remote_host,
 		runtime_options.remote_user,
 		command,
-		&command_output);
+		NULL);
 
 	termPQExpBuffer(&command_output);
 
@@ -5956,15 +5956,18 @@ remote_command(const char *host, const char *user, const char *command, PQExpBuf
 		return false;
 	}
 
-	/* TODO: better error handling */
-	while (fgets(output, MAXLEN, fp) != NULL)
+	if (outputbuf != NULL)
 	{
-		appendPQExpBuffer(outputbuf, "%s", output);
+		/* TODO: better error handling */
+		while (fgets(output, MAXLEN, fp) != NULL)
+		{
+			appendPQExpBuffer(outputbuf, "%s", output);
+		}
 	}
-
 	pclose(fp);
 
-	log_verbose(LOG_DEBUG, "remote_command(): output returned was:\n%s", outputbuf->data);
+	if (outputbuf != NULL)
+		log_verbose(LOG_DEBUG, "remote_command(): output returned was:\n%s", outputbuf->data);
 
 	return true;
 }


### PR DESCRIPTION
If outputbuf == NULL, then we don't try collecting the output of a remote command.