### PR TITLE
Improved "repmgr-auto" Debian package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,12 @@ PG_VERSION = $(shell pg_config --version | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
 REPMGR_VERSION = $(shell grep REPMGR_VERSION version.h | cut -d ' ' -f 3 | cut -d '"' -f 2)
 PKGLIBDIR = $(shell pg_config --pkglibdir)
 SHAREDIR = $(shell pg_config --sharedir)
+PGBINDIR = /usr/lib/postgresql/$(PG_VERSION)/bin
 
 deb: repmgrd repmgr
-	mkdir -p ./debian/usr/bin
-	cp repmgrd repmgr ./debian/usr/bin/
+	mkdir -p ./debian/usr/bin ./debian$(PGBINDIR)
+	cp repmgrd repmgr ./debian$(PGBINDIR)
+	ln -s ../..$(PGBINDIR)/repmgr ./debian/usr/bin/repmgr
 	mkdir -p ./debian$(SHAREDIR)/contrib/
 	cp sql/repmgr_funcs.sql ./debian$(SHAREDIR)/contrib/
 	cp sql/uninstall_repmgr_funcs.sql ./debian$(SHAREDIR)/contrib/

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: repmgr-auto
-Version: 3.1.3
+Version: 3.2dev
 Section: database
 Priority: optional
 Architecture: all


### PR DESCRIPTION
* Version set to 3.2dev

* Binaries are placed in PGBINDIR and then linked from /usr/bin,
  instead of being placed into /usr/bin directly. This is necessary
  for the switchover command, because it requires pg_rewind, which is
  placed in PGBINDIR too.