### PR TITLE
Fix inconsistent repmgr.conf path in failover cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,8 +970,8 @@ To use `repmgrd` for automatic failover, the following `repmgrd` options must
 be set in `repmgr.conf`:
 
     failover=automatic
-    promote_command='repmgr standby promote -f /etc/repmgr/repmgr.conf'
-    follow_command='repmgr standby follow -f /etc/repmgr/repmgr.conf'
+    promote_command='repmgr standby promote -f /etc/repmgr.conf'
+    follow_command='repmgr standby follow -f /etc/repmgr.conf'
 
 (See `repmgr.conf.sample` for further `repmgrd`-specific settings).
 


### PR DESCRIPTION
The examples of `promote_command` and `follow_command` reference the `repmgr.conf` file under a different path from the rest of the README. This makes them consistent with the rest of the README.