### PR TITLE
Fixing inaccurate option checking (#230)

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -863,9 +863,11 @@ main(int argc, char **argv)
 
 	if (action == STANDBY_CLONE &&
 		! runtime_options.without_barman
-		&& strcmp(options.barman_server, "") == 0)
+		&& strcmp(options.barman_server, "") != 0
+		&& options.use_replication_slots)
 		{
 			log_err(_("STANDBY CLONE in Barman mode is incompatible with configuration option \"use_replication_slots\""));
+			exit(ERR_BAD_CONFIG);
 		}
 
 	/* Initialise the repmgr schema name */

--- a/repmgr.c
+++ b/repmgr.c
@@ -5179,8 +5179,10 @@ create_recovery_file(const char *data_dir, PGconn *primary_conn, const char *con
 		{
 			case NO_UPSTREAM_NODE:
 				maxlen_snprintf(where_condition, "type='master'");
+				break;
 			default:
 				maxlen_snprintf(where_condition, "id=%d", options.upstream_node);
+				break;
 		}
 
 		initPQExpBuffer(&command_output);


### PR DESCRIPTION
The incompatibility between Barman mode and use_replication_slots was
not checked properly, and did not cause repmgr to exit.