### PR TITLE
When restoring from Barman, create pg_logical subdirectories

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -3315,14 +3315,14 @@ do_standby_clone(void)
 					/* Only from 9.5 */
 					"pg_commit_ts",
 					/* Only from 9.4 */
-					"pg_dynshmem", "pg_logical", "pg_replslot",
+					"pg_dynshmem", "pg_logical", "pg_logical/snapshot", "pg_logical/mappings", "pg_replslot",
 					/* Already in 9.3 */
 					"pg_serial", "pg_snapshots", "pg_stat", "pg_stat_tmp", "pg_tblspc",
 					"pg_twophase", "pg_xlog", 0
 				};
 				const int vers[] = {
 					90500,
-					90400, 90400, 90400,
+					90400, 90400, 90400, 90400, 90400,
 					0, 0, 0, 0, 0,
 					0, 0, 0
 				};


### PR DESCRIPTION
Certain nodes cloned from Barman backups were missing these subdirectories, and so they were unable to start when promoted.
The problem happened because we fetch the list of files, which currently excludes empty directories, and pull them from the local side, rather than executing remotely `barman recover` to push files.