### PR TITLE
    Add an option remote_command_prefix

### DIFF
--- a/config.c
+++ b/config.c
@@ -268,6 +268,9 @@ _parse_config(t_configuration_options *options, ItemList *error_list)
 	options->tablespace_mapping.head = NULL;
 	options->tablespace_mapping.tail = NULL;
 
+	/* Remote command prefix */ 
+	memset(options->remote_command_prefix, 0, sizeof(options->remote_command_prefix));
+
 	/*
 	 * If no configuration file available (user didn't specify and none found
 	 * in the default locations), return with default values
@@ -414,6 +417,9 @@ _parse_config(t_configuration_options *options, ItemList *error_list)
 			tablespace_list_append(options, value);
 		else if (strcmp(name, "restore_command") == 0)
 			strncpy(options->restore_command, value, MAXLEN);
+		/* Remote command prefix */
+		else if (strcmp(name, "remote_command_prefix") == 0)
+			strncpy(options->remote_command_prefix, value, MAXLEN);
 		else
 		{
 			known_parameter = false;
@@ -582,6 +588,7 @@ parse_line(char *buf, char *name, char *value)
  * - reconnect_interval
  * - retry_promote_interval_secs
  * - witness_repl_nodes_sync_interval_secs
+ * - remote_command_prefix
  *
  * non-changeable options:
  * - cluster_name
@@ -746,6 +753,13 @@ reload_config(t_configuration_options *orig_options)
 	{
 		strcpy(orig_options->loglevel, new_options.loglevel);
 		log_config_changed = true;
+	}
+
+	/* remote_command_prefix */
+	if (strcmp(orig_options->remote_command_prefix, new_options.remote_command_prefix) != 0)
+	{
+		strcpy(orig_options->remote_command_prefix, new_options.remote_command_prefix);
+		config_changed = true;
 	}
 
 	if (log_config_changed == true)

--- a/config.h
+++ b/config.h
@@ -89,6 +89,8 @@ typedef struct
 	int			witness_repl_nodes_sync_interval_secs;
 	int			use_replication_slots;
 	char		event_notification_command[MAXLEN];
+	/* Remote command prefix */ 
+	char		remote_command_prefix[MAXLEN];
 	EventNotificationList event_notifications;
 	TablespaceList tablespace_mapping;
 }	t_configuration_options;
@@ -97,7 +99,7 @@ typedef struct
  * The following will initialize the structure with a minimal set of options;
  * actual defaults are set in parse_config() before parsing the configuration file
  */
-#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", UNKNOWN_NODE_ID, NO_UPSTREAM_NODE, "", "", "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", { NULL, NULL }, { NULL, NULL } }
+#define T_CONFIGURATION_OPTIONS_INITIALIZER { "", UNKNOWN_NODE_ID, NO_UPSTREAM_NODE, "", "", "", MANUAL_FAILOVER, -1, "", "", "", "", "", "", "", "", "", "", "", "", -1, -1, -1, "", "", "", "", "", 0, 0, 0, 0, "", "", { NULL, NULL }, { NULL, NULL } }
 
 typedef struct ItemListCell
 {

--- a/repmgr.c
+++ b/repmgr.c
@@ -244,6 +244,8 @@ main(int argc, char **argv)
 		{"initdb-no-pwprompt", no_argument, NULL, OPT_INITDB_NO_PWPROMPT},
 		{"ignore-external-config-files", no_argument, NULL, OPT_IGNORE_EXTERNAL_CONFIG_FILES},
 		{"no-conninfo-password", no_argument, NULL, OPT_NO_CONNINFO_PASSWORD},
+		/* Remote command prefix */
+		{"remote-command-prefix", optional_argument, NULL, 'C'},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -8253,9 +8255,10 @@ remote_command(const char *host, const char *user, const char *command, PQExpBuf
 	appendPQExpBuffer(&ssh_host, "%s",host);
 
 	maxlen_snprintf(ssh_command,
-					"ssh -o Batchmode=yes %s %s %s",
+					"ssh -o Batchmode=yes %s %s %s %s",
 					options.ssh_options,
 					ssh_host.data,
+					options.remote_command_prefix,
 					command);
 
 	termPQExpBuffer(&ssh_host);

--- a/repmgr.conf.sample
+++ b/repmgr.conf.sample
@@ -116,6 +116,10 @@
 # Debian/Ubuntu users: you will probably need to set this to the directory
 # where `pg_ctl` is located, e.g. /usr/lib/postgresql/9.5/bin/
 
+# remote command prefix to add before the remote command name
+# for example to enable Software Collection on Redhat before running a remote command
+#remote_command_prefix=scl enable rh-postgresql95 --
+
 # service control commands
 #
 # repmgr provides options to override the default pg_ctl commands

--- a/repmgr.h
+++ b/repmgr.h
@@ -66,6 +66,7 @@
 #define OPT_UPSTREAM_CONNINFO            15
 #define OPT_NO_CONNINFO_PASSWORD         16
 #define OPT_REPLICATION_USER             17
+#define OPT_REMOTE_COMMAND_PREFIX		 18
 
 /* deprecated command line options */
 #define OPT_INITDB_NO_PWPROMPT           998
@@ -144,6 +145,9 @@ typedef struct
 	/* {standby|witness} unregister parameters */
 	int			node;
 
+	/* Remote command prefix*/ 
+	char		remote_command_prefix[MAXLEN];
+
 }	t_runtime_options;
 
 #define T_RUNTIME_OPTIONS_INITIALIZER { \
@@ -170,7 +174,9 @@ typedef struct
 		/* standby {archive_config | restore_config} parameters  */ \
 		"",                             \
 		/* {standby|witness} unregister parameters */ \
-		UNKNOWN_NODE_ID }
+		UNKNOWN_NODE_ID, \
+		/* Remote command prefix*/ \
+		"" }
 
 struct BackupLabel
 {


### PR DESCRIPTION
Hello

I am using Repmgr with a Redhat Software Collection Postgresql95 package.
There is a problem running remote commands because we have to enable the software collection before running a command, else the executable does not found the libraries.
This is the case with the switchover command when trying to run repmgr and pg_rewind

For using it, add this line in repmgr.conf file :
remote_command_prefix=scl enable rh-postgresql95 --

For compiling Repmgr when using Redhat SCL :
scl enable rh-postgresql95 "make USE_PGXS=1 install"

repmgr: Add the remote_command_prefix option in the repmgr.conf file
             Add the remote_command_prefix option before running a remote command in the remote_command function
             This could be used to enable on Redhat the Software Collection for example do a switchover

Regards