### PR TITLE
switchover gets stuck rebooting remote server at standy follow step

### DIFF
--- a/repmgr.c
+++ b/repmgr.c
@@ -5482,7 +5482,7 @@ do_standby_switchover(void)
 		remote_host,
 		runtime_options.remote_user,
 		remote_command_str.data,
-		NULL);
+		&command_output);
 
 	termPQExpBuffer(&remote_command_str);
 
@@ -8356,6 +8356,10 @@ local_command(const char *command, PQExpBufferData *outputbuf)
 		while (fgets(output, MAXLEN, fp) != NULL)
 		{
 			appendPQExpBuffer(outputbuf, "%s", output);
+			 if(!feof(fp))
+                        {
+                                break;
+                        }
 		}
 
 		pclose(fp);


### PR DESCRIPTION
Hi
When doing the switchover

`repmgr --verbose --log-level=DEBUG -f /home/postgres/repmgr_db2.conf -C /home/postgres/repmgr_db1.conf standby switchover `

it gets stuck waiting to restart the remote DB at the standy follow step:

`DEBUG: Executing:
repmgr -D '/data/db1' -f '/home/postgres/repmgr_db1.conf' -h XXX.XXX.XXX.2 -d repmgr -U repmgr  standby follow
DEBUG: remote_command(): ssh -o Batchmode=yes  XXX.XXX.XXX.1 repmgr -D '/data/db1' -f '/home/postgres/repmgr_db1.conf' -h  XXX.XXX.XXX.2 -d repmgr -U repmgr  standby follow
NOTICE: restarting server using 'pg_ctl  -w -D /data/db1 -m fast restart'
pg_ctl: PID file "/data/db1/postmaster.pid" does not exist
Is server running?
starting server anyway
`

At this point it gets stuck on the while loop and it doesn't move on.

After the fix, the switchover finishes succesfully:

`DEBUG: Executing:
repmgr -D '/data/db1' -f '/home/postgres/repmgr_db1.conf' -h XXX.XXX.XXX.2 -d repmgr -U repmgr  standby follow
DEBUG: remote_command(): ssh -o Batchmode=yes  XXX.XXX.XXX.1 repmgr -D '/data/db1' -f '/home/postgres/repmgr_db1.conf' -h  XXX.XXX.XXX.2 -d repmgr -U repmgr  standby follow
NOTICE: restarting server using 'pg_ctl  -w -D /data/db1 -m fast restart'
pg_ctl: PID file "/data/db1/postmaster.pid" does not exist
Is server running?
starting server anyway
DEBUG: remote_command(): output returned was:
DEBUG: connecting to: 'host=xxx.xxx.xxx..1 port=5432 user=repmgr dbname=repmgr fallback_application_name='repmgr''
DEBUG: connected to new standby (old master)
DEBUG: is_standby(): SELECT pg_catalog.pg_is_in_recovery()
DEBUG: new standby is in recovery
DEBUG: connecting to: 'host=xxx.xxx.xxx.2 port=5432 user=repmgr dbname=repmgr fallback_application_name='repmgr''
NOTICE: node 1 is replicating in state "streaming"
DEBUG: create_event_record():
 INSERT INTO "repmgr_test".repl_events (              node_id,              event,              successful,              details             )       VALUES ($1, $2, $3, $4)    RETURNING event_timestamp
DEBUG: create_event_record(): Event timestamp is "2017-02-02 14:27:19.577572+00"
NOTICE: switchover was successful
`
