### PR TITLE
Update repmgrd logrotate example

### DIFF
--- a/doc/repmgrd-configuration.sgml
+++ b/doc/repmgrd-configuration.sgml
@@ -319,8 +319,10 @@ REPMGRD_ENABLED=no
         rotate 52
         maxsize 100M
         weekly
-        create 0600 postgres postgres
+        copytruncate
     }</programlisting>
+    <application>repmgrd</application> currently does not reopen the logfile on HUP signal.
+    Usage of <command>copytruncate</command> option of <command>logrotate</command> is required.
   </para>
  </sect1>
 </chapter>


### PR DESCRIPTION
The old logrotate configuration example might cause a situation in which repmgrd still has an open file descriptor to the logfile, but the file has already been rotated&removed by logrotate:
```
$ sudo ls -l /proc/`pidof repmgrd`/fd
total 0
lr-x------ 1 postgres postgres 64 Jul  3 14:30 0 -> /dev/null
l-wx------ 1 postgres postgres 64 Jul  3 14:30 1 -> /dev/null
l-wx------ 1 postgres postgres 64 Jul  3 14:30 2 -> /var/log/repmgr/repmgr-9.4.log.1 (deleted)
lrwx------ 1 postgres postgres 64 Jul  3 14:30 3 -> socket:[246459548]
```
You can still access the logfile via `cat /proc/PID/fd/2`, but the /var/log/repmgr/repmgr-9.4.log is empty.

Setting up logrotate with copytruncate option is a workaround for that issue.

Another proposal would be to send a SIGHUP to repmgrd on file rotation, but currently the logfile file descriptor gets reopened only if the configuration is changed. See:
https://github.com/2ndQuadrant/repmgr/blob/b2081dca523ca9ad6e516ba55302260f22272a2a/repmgrd-physical.c#L549
Also configuration reload caused by logrotate seems like a bad idea.

Another signal could be used for reopening the logfile, but copytruncate works well enough so I don't think it's that necessary.