### PR TITLE
Change log_level default to INFO

### DIFF
--- a/log.c
+++ b/log.c
@@ -42,7 +42,7 @@ _stderr_log_with_level(const char *level_name, int level, const char *fmt, va_li
 __attribute__((format(PG_PRINTF_ATTRIBUTE, 3, 0)));
 
 int			log_type = REPMGR_STDERR;
-int			log_level = LOG_NOTICE;
+int			log_level = LOG_INFO;
 int			last_log_level = LOG_INFO;
 int			verbose_logging = false;
 int			terse_logging = false;


### PR DESCRIPTION
The default log_level in the config file is "INFO", so this change will make the code match the conf.