### PR TITLE
Check for exclusive backups when executing switchover action

### DIFF
--- a/dbutils.c
+++ b/dbutils.c
@@ -3953,7 +3953,31 @@ connection_ping(PGconn *conn)
 	return;
 }
 
+/*
+ * Function that checks if the primary is in exclusive backup mode.
+ * We'll use this when executing an action can conflict with an exclusive
+ * backup.
+ */
+bool
+server_not_in_exclusive_backup_mode(PGconn *conn)
+{
+	PGresult   *res = PQexec(conn, "SELECT pg_is_in_backup()");
 
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		log_error(_("unable to retrieve information regarding backup mode of node"));
+		log_detail("%s", PQerrorMessage(conn));
+		PQclear(res);
+		return false;
+	}
+
+	if (strcmp(PQgetvalue(res, 0, 0), "t") == 0)
+	{
+		log_warning(_("node is in exclusive backup mode"));
+		return false;
+	}
+	return true;
+}
 
 /* ==================== */
 /* monitoring functions */

--- a/dbutils.h
+++ b/dbutils.h
@@ -467,6 +467,7 @@ int			wait_connection_availability(PGconn *conn, long long timeout);
 bool		is_server_available(const char *conninfo);
 bool		is_server_available_params(t_conninfo_param_list *param_list);
 void		connection_ping(PGconn *conn);
+bool            server_not_in_exclusive_backup_mode(PGconn *conn);
 
 /* monitoring functions  */
 void

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -2912,6 +2912,24 @@ do_standby_switchover(void)
 	}
 
 	/*
+	 * Check that there's no exclusive backups running on the primary.
+	 * We don't want to end up damaging the backup and also leaving the server in an
+	 * state where there's control data saying it's in backup mode but there's no
+	 * backup_label in PGDATA.
+	 * If the DBA want's to do the switchover anyway, he should first stop the
+	 * backup that's running.
+	 */
+	if (!server_not_in_exclusive_backup_mode(remote_conn))
+	{
+		log_error(_("can't perform a switchover while primary server is in exclusive backup mode"));
+		log_hint(_("stop backup before attempting the switchover"));
+
+		PQfinish(remote_conn);
+
+		exit(ERR_SWITCHOVER_FAIL);
+	}
+
+	/*
 	 * Check this standby is attached to the demotion candidate
 	 * TODO:
 	 *  - check application_name in pg_stat_replication

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -2916,7 +2916,7 @@ do_standby_switchover(void)
 	 * We don't want to end up damaging the backup and also leaving the server in an
 	 * state where there's control data saying it's in backup mode but there's no
 	 * backup_label in PGDATA.
-	 * If the DBA want's to do the switchover anyway, he should first stop the
+	 * If the DBA wants to do the switchover anyway, he should first stop the
 	 * backup that's running.
 	 */
 	if (!server_not_in_exclusive_backup_mode(remote_conn))


### PR DESCRIPTION
This will check if there's an exclusive backup taking place and cancel the switchover if so.

We might want to do something similar in case of running the failover action as well.