### PR TITLE
add readline-devel to dependencies

### DIFF
--- a/doc/install-source.sgml
+++ b/doc/install-source.sgml
@@ -56,7 +56,7 @@ deb-src http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main</programlisti
       <programlisting>
        sudo yum check-update
        sudo yum groupinstall "Development Tools"
-       sudo yum install yum-utils openjade docbook-dtds docbook-style-dsssl docbook-style-xsl
+       sudo yum install yum-utils openjade docbook-dtds docbook-style-dsssl docbook-style-xsl readline-devel
        sudo yum-builddep postgresql96</programlisting>
      </para>
     </listitem>


### PR DESCRIPTION
On my Centos 6.8 with Postgres compiled from source. 
I performed, as current docs suggest:
sudo yum check-update
sudo yum groupinstall "Development Tools"
sudo yum install yum-utils openjade docbook-dtds docbook-style-dsssl docbook-style-xsl
and skipped build-dep because postgres package was indeed not installed via package manager.
I therefore:
./configure 
which went OK, and:
make install which returned error: 

/usr/bin/ld: cannot find -lreadline
collect2: ld returned 1 exit status
make: *** [repmgr] Error 1

I was then able to fix it, installing the proposed package readline-devel