### PR TITLE
add '-h primary_node' option to the help, since it is mandatory

### DIFF
--- a/repmgr-action-witness.c
+++ b/repmgr-action-witness.c
@@ -482,7 +482,7 @@ void do_witness_help(void)
 	print_help_header();
 
 	printf(_("Usage:\n"));
-	printf(_("    %s [OPTIONS] witness register\n"), progname());
+	printf(_("    %s [OPTIONS] witness register -h primary_node\n"), progname());
 	printf(_("    %s [OPTIONS] witness unregister\n"), progname());
 
 	printf(_("WITNESS REGISTER\n"));


### PR DESCRIPTION
It is not possible to perform a witness registration without passing the '-h' parameter. 
In my opinion the parameter should be explicitely mentioned in the line I propose to change.
If you do not like my change, as alternative (or integration to it) I think '-h' parameter should be also mentioned  at line 493, for clarity.
It resulted difficult to me to understand the error that is returned when '-h' is missing:

The following command line errors were encountered:
  host name for the source node must be provided when executing WITNESS REGISTER
Try "repmgr --help" or "repmgr witness --help" for more information.

and line 492 was not explicit enough on how to pass the "connection information for the primary"

and only this page could help: 
https://repmgr.org/docs/repmgr.html#REPMGR-WITNESS-REGISTER

If my commit is accepted, i think it would be good to also make the change consistent on 'repmgr --help'