### PR TITLE
repmgr-client.c:1895:33: error: ‘TRUE’ undeclared

### DIFF
--- a/repmgr-client.c
+++ b/repmgr-client.c
@@ -1892,7 +1892,7 @@ check_cli_parameters(const int action)
 
 	/* --compact */
 
-	if (runtime_options.compact == TRUE)
+	if (runtime_options.compact == true)
 	{
 		switch (action)
 		{


### PR DESCRIPTION
repmgr-client.c:1895:33: error: ‘TRUE’ undeclared (first use in this function)
  if (runtime_options.compact == TRUE)
                                 ^
repmgr-client.c:1895:33: note: each undeclared identifier is reported only once for each function it appears in
make: *** [repmgr-client.o] Error 1