### PR TITLE
Add dbname=replication to local replication check

### DIFF
--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -2862,6 +2862,8 @@ do_standby_follow(void)
 
 		param_set(&local_repl_conninfo, "replication", "1");
 
+		param_set(&local_repl_conninfo, "dbname", "replication");
+
 		local_repl_conn = establish_db_connection_by_params(&local_repl_conninfo, false);
 		free_conninfo_params(&local_repl_conninfo);
 


### PR DESCRIPTION
In cases where a dedicated replication user is specified in repmgr
config, this connection attempt would fail since it was missing
"dbname=replication" if pg_hba is set to only allow replication
connections for the dedicated replication user.

This check was added in tag v4.3.0 and were missing this fix from previous
commit: a8ae791bcbb5230ea26f7fcff47a711a4348a546

Addresses GitHub #605