### PR TITLE
Failover follow attempt: fix inverted log message

### DIFF
--- a/repmgrd-physical.c
+++ b/repmgrd-physical.c
@@ -3655,7 +3655,7 @@ follow_new_primary(int new_primary_id)
 		else
 		{
 			new_primary_ok = false;
-			log_warning(_("new primary is not in recovery"));
+			log_warning(_("new primary is in recovery"));
 			close_connection(&upstream_conn);
 		}
 	}
@@ -3848,7 +3848,7 @@ witness_follow_new_primary(int new_primary_id)
 				break;
 			case RECTYPE_STANDBY:
 				new_primary_ok = false;
-				log_warning(_("new primary is not in recovery"));
+				log_warning(_("new primary is in recovery"));
 				break;
 			case RECTYPE_UNKNOWN:
 				new_primary_ok = false;


### PR DESCRIPTION
When trying to follow a new primary, the type of the new primary is checked. When it is *not* of type primary, a warning is logged and the follow attempt is aborted. As far as I can tell, the message itself is exactly the opposite of what it should be: The node is not primary, thus it is standby / "in recovery". Feel free to correct me if I’m misunderstanding.