### PR TITLE
Add %v, %u and %t parameters to the failover_validation_command

### DIFF
--- a/dbutils.c
+++ b/dbutils.c
@@ -2896,6 +2896,37 @@ get_all_node_records(PGconn *conn, NodeInfoList *node_list)
 	return success;
 }
 
+bool
+get_all_nodes_count(PGconn *conn, int *count)
+{
+	PQExpBufferData query;
+	PGresult   *res = NULL;
+	bool success = true;
+	initPQExpBuffer(&query);
+
+	appendPQExpBufferStr(&query,
+						 "  SELECT count(*) "
+						 "    FROM repmgr.nodes n ");
+
+	log_verbose(LOG_DEBUG, "get_all_nodes_count():\n%s", query.data);
+
+	res = PQexec(conn, query.data);
+
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		log_db_error(conn, query.data, _("get_all_nodes_count(): unable to execute query"));
+		success = false;
+	}
+	else
+	{
+		*count = atoi(PQgetvalue(res, 0, 0));
+	}
+
+	PQclear(res);
+	termPQExpBuffer(&query);
+
+	return success;
+}
 
 void
 get_downstream_node_records(PGconn *conn, int node_id, NodeInfoList *node_list)

--- a/dbutils.h
+++ b/dbutils.h
@@ -491,6 +491,7 @@ bool		get_local_node_record(PGconn *conn, int node_id, t_node_info *node_info);
 bool		get_primary_node_record(PGconn *conn, t_node_info *node_info);
 
 bool		get_all_node_records(PGconn *conn, NodeInfoList *node_list);
+bool		get_all_nodes_count(PGconn *conn, int *count);
 void		get_downstream_node_records(PGconn *conn, int node_id, NodeInfoList *nodes);
 void		get_active_sibling_node_records(PGconn *conn, int node_id, int upstream_node_id, NodeInfoList *node_list);
 bool		get_child_nodes(PGconn *conn, int node_id, NodeInfoList *node_list);


### PR DESCRIPTION
Indicating the number of visible nodes sharing the current upstream,
the number of nodes on the current upstream as well as the total
number of nodes in the entire repmgr cluster.

This allows the failover_validation_command to be used to perform
more thorough validations, including cross-referencing external
cluster management state (e.g. if managed by kubernetes).