### PR TITLE
Fix help witness

### DIFF
--- a/repmgr-action-witness.c
+++ b/repmgr-action-witness.c
@@ -560,7 +560,7 @@ void do_witness_help(void)
 
 	printf(_("WITNESS UNREGISTER\n"));
 	puts("");
-	printf(_("  \"witness register\" unregisters a witness node.\n"));
+	printf(_("  \"witness unregister\" unregisters a witness node.\n"));
 	puts("");
 	printf(_("  --dry-run                check prerequisites but don't make any changes\n"));
 	printf(_("  -F, --force              unregister when witness node not running\n"));


### PR DESCRIPTION
Fix the `repmgr witness --help` command where at the "Unregister" section the message shown was
```
"witness register" unregisters a witness node.
```
instead of
```
"witness unregister" unregisters a witness node.
```