### PR TITLE
#780: do not log any connection string above DEBUG level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ repmgr4
 repmgrd4
 
 # generated files
+repmgr.bc
 configfile-scan.c

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,6 @@
+5.x.x   2022-12-xx
+        Ensure connection string is not loggued above DEBUG level
+
 5.3.3   2022-10-17
         Support for PostgreSQL added
         repmgrd: ensure event notification script is called for event

--- a/dbutils.c
+++ b/dbutils.c
@@ -142,7 +142,7 @@ _establish_db_connection(const char *conninfo, const bool exit_on_error, const b
 
 	if (parse_success == false)
 	{
-		log_error(_("unable to parse provided conninfo string \"%s\""), conninfo);
+		log_error(_("unable to parse provided conninfo string"));
 		log_detail("%s", errmsg);
 		free_conninfo_params(&conninfo_params);
 		return NULL;
@@ -260,8 +260,7 @@ establish_db_connection_with_replacement_param(const char *conninfo,
 
 	if (parse_success == false)
 	{
-		log_error(_("unable to parse conninfo string \"%s\" for local node"),
-				  conninfo);
+		log_error(_("unable to parse conninfo string for local node"));
 		log_detail("%s", errmsg);
 
 		if (exit_on_error == true)
@@ -476,7 +475,7 @@ get_conninfo_value(const char *conninfo, const char *keyword, char *output)
 
 	if (conninfo_options == NULL)
 	{
-		log_error(_("unable to parse provided conninfo string \"%s\""), conninfo);
+		log_error(_("unable to parse provided conninfo string"));
 		return false;
 	}
 
@@ -884,7 +883,7 @@ normalize_conninfo_string(const char *conninfo_str)
 
 	if (parse_success == false)
 	{
-		log_error(_("unable to parse provided conninfo string \"%s\""), conninfo_str);
+		log_error(_("unable to parse provided conninfo string"));
 		log_detail("%s", errmsg);
 		free_conninfo_params(&conninfo_params);
 		return NULL;
@@ -4964,7 +4963,7 @@ _is_server_available(const char *conninfo, bool quiet)
 
 	if (quiet == false)
 	{
-		log_warning(_("unable to ping \"%s\""), conninfo);
+		log_warning(_("unable to ping"));
 		log_detail(_("PQping() returned \"%s\""), print_pqping_status(status));
 	}
 
@@ -4987,7 +4986,7 @@ is_server_available_params(t_conninfo_param_list *param_list)
 
 		if (status != PQPING_OK)
 		{
-			log_warning(_("unable to ping \"%s\""), conninfo_str);
+			log_warning(_("unable to ping"));
 			log_detail(_("PQping() returned \"%s\""), print_pqping_status(status));
 		}
 

--- a/repmgr-action-node.c
+++ b/repmgr-action-node.c
@@ -803,8 +803,7 @@ do_node_check(void)
 									 ERR_BAD_CONFIG);
 			}
 
-			log_error(_("unable to parse conninfo string \"%s\" for local node"),
-					  config_file_options.conninfo);
+			log_error(_("unable to parse conninfo string for local node"));
 			log_detail("%s", errmsg);
 
 			exit(ERR_BAD_CONFIG);
@@ -2671,7 +2670,7 @@ do_node_rejoin(void)
 		log_error(_("unable to connect to current registered primary \"%s\" (ID: %i)"),
 				  primary_node_record.node_name,
 				  primary_node_record.node_id);
-		log_detail(_("registered primary node conninfo is: \"%s\""),
+		log_debug(_("registered primary node conninfo is: \"%s\""),
 				   primary_node_record.conninfo);
 		/*
 		 * Catch case where provided upstream is not in recovery, but is also

--- a/repmgr-action-primary.c
+++ b/repmgr-action-primary.c
@@ -274,9 +274,10 @@ do_primary_unregister(void)
 
 		if (get_primary_node_record(local_conn, &primary_node_info) == true)
 		{
-			log_detail(_("current primary registered as node \"%s\" (ID: %i, conninfo: \"%s\")"),
+			log_detail(_("current primary registered as node \"%s\" (ID: %i)"),
 					   primary_node_info.node_name,
-					   primary_node_info.node_id,
+					   primary_node_info.node_id);
+			log_debug(_("conninfo: \"%s\""),
 					   primary_node_info.conninfo);
 		}
 

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -429,8 +429,7 @@ do_standby_clone(void)
 
 		if (parse_success == false)
 		{
-			log_error(_("unable to parse conninfo string \"%s\" for upstream node"),
-					  recovery_conninfo_str);
+			log_error(_("unable to parse conninfo string for upstream node"));
 			log_detail("%s", errmsg);
 			if (PQstatus(source_conn) == CONNECTION_OK)
 				PQfinish(source_conn);
@@ -6127,8 +6126,8 @@ check_source_server_via_barman()
 
 	if (parse_success == false)
 	{
-		log_error(_("Unable to parse barman conninfo string \"%s\":\n%s"),
-				  barman_conninfo_str, errmsg);
+		log_error(_("Unable to parse barman conninfo string: %s"),
+			errmsg);
 		exit(ERR_BARMAN);
 	}
 

--- a/repmgr-action-witness.c
+++ b/repmgr-action-witness.c
@@ -154,7 +154,7 @@ do_witness_register(void)
 	if (PQstatus(primary_conn) != CONNECTION_OK)
 	{
 		log_error(_("unable to reconnect to the primary node (node %i)"), primary_node_id);
-		log_detail(_("primary node's conninfo is \"%s\""), primary_node_record.conninfo);
+		log_debug(_("primary node's conninfo is \"%s\""), primary_node_record.conninfo);
 
 		PQfinish(witness_conn);
 

--- a/repmgrd.c
+++ b/repmgrd.c
@@ -842,7 +842,7 @@ check_upstream_connection(PGconn **conn, const char *conninfo, PGconn **paired_c
 
 			if (PQstatus(test_conn) != CONNECTION_OK)
 			{
-				log_warning(_("unable to connect to \"%s\""), conninfo);
+				log_warning(_("unable to connect"));
 				log_detail("\n%s", PQerrorMessage(test_conn));
 				success = false;
 			}


### PR DESCRIPTION
#780: do not log connection string above DEBUG level

_Remark_
* This is a quick fix to solve vulnerability issue
* Further enhancement should attempt to sanitize information passed to `unable to connect` and `unable to ping` messages in order to still give valuable hints to admin