### PR TITLE
fix missing dbname for sync_replication_slots

### DIFF
--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -8368,6 +8368,7 @@ write_primary_conninfo(PQExpBufferData *dest, t_conninfo_param_list *param_list)
 	PQExpBufferData conninfo_buf;
 	bool		application_name_provided = false;
 	bool		password_provided = false;
+	bool		dbname_found = false;
 	int			c;
 	char	   *escaped = NULL;
 	t_conninfo_param_list env_conninfo = T_CONNINFO_PARAM_LIST_INITIALIZER;
@@ -8382,11 +8383,17 @@ write_primary_conninfo(PQExpBufferData *dest, t_conninfo_param_list *param_list)
 		 * Skip empty settings and ones which don't make any sense in
 		 * recovery.conf
 		 */
-		if (strcmp(param_list->keywords[c], "dbname") == 0 ||
-			strcmp(param_list->keywords[c], "replication") == 0 ||
+		if (strcmp(param_list->keywords[c], "replication") == 0 ||
 			(param_list->values[c] == NULL) ||
 			(param_list->values[c] != NULL && param_list->values[c][0] == '\0'))
 			continue;
+
+		if (strcmp(param_list->keywords[c], "dbname") == 0)
+    	{
+      	dbname_found = true;
+        	appendPQExpBuffer(&conninfo_buf, " dbname=%s", param_list->values[c]);
+        	continue;
+    	}
 
 		/* only include "password" if explicitly requested */
 		if (strcmp(param_list->keywords[c], "password") == 0)

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -8389,11 +8389,11 @@ write_primary_conninfo(PQExpBufferData *dest, t_conninfo_param_list *param_list)
 			continue;
 
 		if (strcmp(param_list->keywords[c], "dbname") == 0)
-    	{
-      	dbname_found = true;
-        	appendPQExpBuffer(&conninfo_buf, " dbname=%s", param_list->values[c]);
-        	continue;
-    	}
+		{
+			dbname_found = true;
+			appendPQExpBuffer(&conninfo_buf, " dbname=%s", param_list->values[c]);
+			continue;
+		}
 
 		/* only include "password" if explicitly requested */
 		if (strcmp(param_list->keywords[c], "password") == 0)

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -8368,7 +8368,6 @@ write_primary_conninfo(PQExpBufferData *dest, t_conninfo_param_list *param_list)
 	PQExpBufferData conninfo_buf;
 	bool		application_name_provided = false;
 	bool		password_provided = false;
-	bool		dbname_found = false;
 	int			c;
 	char	   *escaped = NULL;
 	t_conninfo_param_list env_conninfo = T_CONNINFO_PARAM_LIST_INITIALIZER;


### PR DESCRIPTION
Preserve dbname from upstream conninfo when generating standby primary_conninfo.

Previously, repmgr explicitly skipped the 'dbname' parameter when building primary_conninfo for standby nodes. This worked fine for all versions prior to PostgreSQL 17 because the replication protocol ignores dbname.

However, in PostgreSQL 17+, the sync_replication_slots worker requires a valid dbname in the connection string. Without this change, standby nodes cannot use replication slots after failover or switchover.

This patch preserves the dbname from the upstream node's conninfo, if present, without adding any defaults. This approach is fully backward-compatible with older PostgreSQL versions and does not affect the existing replication logic.