### PR TITLE
pg_rewind --restore-target-wal

### DIFF
--- a/doc/repmgr-node-rejoin.xml
+++ b/doc/repmgr-node-rejoin.xml
@@ -87,6 +87,16 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--force-rewind-wal-recovery</option></term>
+        <listitem>
+          <para>
+            Add <option>--restore-target-wal</option> to the <application>pg_rewind</application>
+            execution.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--config-files</option></term>
         <listitem>
           <para>

--- a/doc/switchover.xml
+++ b/doc/switchover.xml
@@ -233,6 +233,11 @@
       To have &repmgr; execute <application>pg_rewind</application> if it detects this
       situation after promoting the new primary, add the <option>--force-rewind</option>
       option.
+      If <application>pg_rewind</application> is used, the
+      <option>--force-rewind-wal-recovery</option> option can be provided to cause
+      &repmgr; to add the <option>--restore-target-wal</option> flag to the
+      <application>pg_rewind</application> command, which ensures all necessary WAL
+      files are available.
     </para>
     <note>
       <simpara>

--- a/repmgr-action-node.c
+++ b/repmgr-action-node.c
@@ -2842,6 +2842,18 @@ do_node_rejoin(void)
 						  " --source-server='%s'",
 						  primary_node_record.conninfo);
 
+		if (runtime_options.force_rewind_wal_recovery == true)
+		{
+			appendPQExpBufferStr(&command,
+								 " --restore-target-wal");
+		}
+
+		if (log_level == LOG_DEBUG)
+		{
+			appendPQExpBufferStr(&command,
+								 " --debug");
+		}
+
 		if (runtime_options.dry_run == true)
 		{
 			log_info(_("pg_rewind would now be executed"));
@@ -2905,8 +2917,14 @@ do_node_rejoin(void)
 
 				exit(ERR_REJOIN_FAIL);
 			}
+			else
+			{
+				log_detail(_("pg_rewind_execution succeeded"));
+				log_detail("%s", command_output.data);
 
-			termPQExpBuffer(&command_output);
+				termPQExpBuffer(&command_output);
+			}
+
 
 			/* Restore any previously archived config files */
 			_do_node_restore_config();
@@ -3692,6 +3710,8 @@ do_node_help(void)
 			 "                              (including usability of \"pg_rewind\" if requested)\n"));
 	printf(_("    --force-rewind[=VALUE]  execute \"pg_rewind\" if necessary\n"));
 	printf(_("                              (PostgreSQL 9.4 - provide full \"pg_rewind\" path)\n"));
+	printf(_("    --force-rewind-wal-recovery\n" \
+			 "                            add \"--restore-target-wal\" to pg_rewind execution\n"));
 
 	printf(_("    --config-files          comma-separated list of configuration files to retain\n" \
 			 "                            after executing \"pg_rewind\"\n"));

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -5345,6 +5345,13 @@ do_standby_switchover(void)
 							  "=%s",
 							  runtime_options.force_rewind_path);
 		}
+
+		if (runtime_options.force_rewind_wal_recovery == true)
+		{
+			appendPQExpBufferStr(&node_rejoin_options,
+								 " --force-rewind-wal-recovery");
+		}
+
 		appendPQExpBufferStr(&node_rejoin_options,
 							 " --config-files=");
 
@@ -9299,6 +9306,7 @@ do_standby_help(void)
 	printf(_("  -F, --force                         ignore warnings and continue anyway\n"));
 	printf(_("  --force-rewind[=VALUE]              use \"pg_rewind\" to reintegrate the old primary if necessary\n"));
 	printf(_("                                        (PostgreSQL 9.4 - provide \"pg_rewind\" path)\n"));
+	printf(_("  --force-rewind-wal-recovery         add \"--restore-target-wal\" to pg_rewind execution\n"));
 
 	printf(_("  -R, --remote-user=USERNAME          database server username for SSH operations (default: \"%s\")\n"), runtime_options.username);
 	printf(_("  -S, --superuser=USERNAME            superuser to use, if repmgr user is not superuser\n"));

--- a/repmgr-client-global.h
+++ b/repmgr-client-global.h
@@ -102,6 +102,7 @@ typedef struct
 	/* "standby switchover" options */
 	bool		always_promote;
 	bool		force_rewind_used;
+	bool		force_rewind_wal_recovery;
 	char		force_rewind_path[MAXPGPATH];
 	bool		siblings_follow;
 	bool		repmgrd_no_pause;
@@ -172,7 +173,7 @@ typedef struct
 		/* "standby register" options */ \
 		false, -1, DEFAULT_WAIT_START,   \
 		/* "standby switchover" options */ \
-		false, false, "", false, false, false,	\
+		false, false, false, "", false, false, false,	\
 		/* "node status" options */ \
 		false, \
 		/* "node check" options */ \

--- a/repmgr-client.c
+++ b/repmgr-client.c
@@ -494,6 +494,10 @@ main(int argc, char **argv)
 
 				break;
 
+			case OPT_FORCE_REWIND_WAL_RECOVERY:
+				runtime_options.force_rewind_wal_recovery = true;
+				break;
+
 			case OPT_SIBLINGS_FOLLOW:
 				runtime_options.siblings_follow = true;
 				break;
@@ -1918,6 +1922,20 @@ check_cli_parameters(const int action)
 			default:
 				item_list_append_format(&cli_warnings,
 										_("--force-rewind will be ignored when executing %s"),
+										action_name(action));
+		}
+	}
+
+	if (runtime_options.force_rewind_wal_recovery == true)
+	{
+		switch (action)
+		{
+			case STANDBY_SWITCHOVER:
+			case NODE_REJOIN:
+				break;
+			default:
+				item_list_append_format(&cli_warnings,
+										_("--force-rewind-wal-recovery will be ignored when executing %s"),
 										action_name(action));
 		}
 	}

--- a/repmgr-client.h
+++ b/repmgr-client.h
@@ -101,6 +101,7 @@
 #define OPT_VERIFY_BACKUP				   1048
 #define OPT_RECOVERY_MIN_APPLY_DELAY       1049
 #define OPT_REPMGRD						   1050
+#define OPT_FORCE_REWIND_WAL_RECOVERY      1051
 
 /* These options are for internal use only */
 #define OPT_CONFIG_ARCHIVE_DIR			   2001
@@ -205,6 +206,7 @@ static struct option long_options[] =
 	{"config-files", required_argument, NULL, OPT_CONFIG_FILES},
     {"config-archive-dir", required_argument, NULL, OPT_CONFIG_ARCHIVE_DIR},
 	{"force-rewind", optional_argument, NULL, OPT_FORCE_REWIND},
+	{"force-rewind-wal-recovery", no_argument, NULL, OPT_FORCE_REWIND_WAL_RECOVERY},
 
 /* "node service" options */
 	{"action", required_argument, NULL, OPT_ACTION},


### PR DESCRIPTION
PostgreSQL 13 introduces _--restore-target-wal_ in pg_rewind to retrieve wal files that are not in the source server but are required for the rewind.

Add a new option to repmgr _--force-rewind-wal-recovery_ to enable that pg_rewind functionality. Optional to not break support pre-v13.

Print the output of pg_rewind even on success, and if repmgr _log_level_ is _DEBUG_ pass _--debug_ to pg_rewind.