### PR TITLE
Standby clone option --without-archive-command

### DIFF
--- a/doc/repmgr-standby-clone.xml
+++ b/doc/repmgr-standby-clone.xml
@@ -459,6 +459,17 @@ pg_basebackup_options='--waldir=/path/to/wal-directory'</programlisting>
       </varlistentry>
 
       <varlistentry>
+        <term><option>--without-archive-command</option></term>
+        <listitem>
+          <para>
+            Allows cloning from a source node where <varname>archive_mode</varname> is enabled
+            but <varname>archive_command</varname> is empty. This is useful when using certain
+            backup tools that require this configuration.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--without-barman </option></term>
         <listitem>
           <para>

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -6437,7 +6437,7 @@ check_upstream_config(PGconn *conn, int server_version_num, t_node_info *upstrea
 	{
 		i = guc_set(conn, "archive_command", "!=", "");
 
-		if (i == 0 || i == -1)
+    if ((i == -1) || (i == 0 && runtime_options.without_archive_command == false))
 		{
 			if (i == 0)
 				log_error(_("parameter \"archive_command\" must be set to a valid command"));

--- a/repmgr-client-global.h
+++ b/repmgr-client-global.h
@@ -90,6 +90,7 @@ typedef struct
 	bool		without_barman;
 	bool		replication_conf_only;
 	bool		verify_backup;
+	bool		without_archive_command;
 
 	/* "standby clone"/"standby follow" options */
 	int			upstream_node_id;
@@ -166,7 +167,7 @@ typedef struct
 		UNKNOWN_NODE_ID, "", "", UNKNOWN_NODE_ID, \
 		/* "standby clone" options */ \
 		false, CONFIG_FILE_SAMEPATH, false, false, false, "", "", "", \
-		false, false, false, \
+		false, false, false, false, \
 		/* "standby clone"/"standby follow" options */ \
 		NO_UPSTREAM_NODE, \
 		/* "standby register" options */ \

--- a/repmgr-client.c
+++ b/repmgr-client.c
@@ -458,6 +458,10 @@ main(int argc, char **argv)
 				runtime_options.verify_backup = true;
 				break;
 
+			case OPT_WITHOUT_ARCHIVE_COMMAND:
+				runtime_options.without_archive_command = true;
+				break;
+
 				/*---------------------------
 				 * "standby register" options
 				 *---------------------------
@@ -2054,6 +2058,20 @@ check_cli_parameters(const int action)
 			default:
 				item_list_append_format(&cli_warnings,
 										_("----siblings-follow is not effective when executing %s"),
+										action_name(action));
+		}
+	}
+
+	/* --without-archive-command */
+	if (runtime_options.without_archive_command == true)
+	{
+		switch (action)
+		{
+			case STANDBY_CLONE:
+				break;
+			default:
+				item_list_append_format(&cli_warnings,
+										_("--without-archive-command is not effective when executing %s"),
 										action_name(action));
 		}
 	}

--- a/repmgr-client.h
+++ b/repmgr-client.h
@@ -101,6 +101,7 @@
 #define OPT_VERIFY_BACKUP				   1048
 #define OPT_RECOVERY_MIN_APPLY_DELAY       1049
 #define OPT_REPMGRD						   1050
+#define OPT_WITHOUT_ARCHIVE_COMMAND		   1051
 
 /* These options are for internal use only */
 #define OPT_CONFIG_ARCHIVE_DIR			   2001
@@ -167,6 +168,7 @@ static struct option long_options[] =
 	{"replication-conf-only", no_argument, NULL, OPT_REPLICATION_CONF_ONLY},
 	{"verify-backup", no_argument, NULL, OPT_VERIFY_BACKUP },
 	{"recovery-min-apply-delay", required_argument, NULL, OPT_RECOVERY_MIN_APPLY_DELAY },
+	{"without-archive-command", no_argument, NULL, OPT_WITHOUT_ARCHIVE_COMMAND},
 	/* deprecate this once Pg11 and earlier are unsupported */
 	{"recovery-conf-only", no_argument, NULL, OPT_REPLICATION_CONF_ONLY},
 


### PR DESCRIPTION
Adds _--without-archive-command_ to _standby clone_. This will keep the check for _archive_mode_ enabled but will allow to have _archive_command_ emtpy as required by some backup solutions.

Implements #902