### PR TITLE
warning: ISO C90 forbids mixed declarations and code

### DIFF
--- a/dbutils.c
+++ b/dbutils.c
@@ -1940,7 +1940,11 @@ can_execute_pg_promote(PGconn *conn)
 bool
 can_disable_walsender(PGconn *conn)
 {
-	/*
+  PQExpBufferData query;
+  PGresult *res;
+  bool has_alter_system_priv = false;
+  
+  /*
 	 * Requires PostgreSQL 9.5 or later, because ALTER SYSTEM
 	 */
 	if (PQserverVersion(conn) < 90500)
@@ -1957,10 +1961,6 @@ can_disable_walsender(PGconn *conn)
 	 */
 	if (is_superuser_connection(conn, NULL) == true)
 		return true;
-
-	PQExpBufferData query;
-	PGresult   *res;
-	bool		has_alter_system_priv = false;
 
 	/* GRANT ALTER SYSTEM available from PostgreSQL 15 */
 	if (PQserverVersion(conn) >= 150000)

--- a/repmgr-action-primary.c
+++ b/repmgr-action-primary.c
@@ -468,8 +468,9 @@ do_primary_unregister(void)
 		}
 		else if (recovery_type == RECTYPE_PRIMARY)
 		{
+      bool		primary_record_found = false;
+
 			reset_node_info(&primary_node_info);
-			bool		primary_record_found = false;
 
 			primary_record_found = get_primary_node_record(primary_conn, &primary_node_info);
 

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -535,7 +535,6 @@ do_standby_clone(void)
 
 		if (external_config_files == true)
 		{
-			r = 0;
 			PQExpBufferData msg;
 
 			initPQExpBuffer(&msg);
@@ -762,7 +761,6 @@ do_standby_clone(void)
 	if (mode == pg_basebackup && runtime_options.verify_backup == true)
 	{
 		PQExpBufferData command;
-		r = 0;
 		struct stat st;
 
 		initPQExpBuffer(&command);
@@ -4783,8 +4781,8 @@ do_standby_switchover(void)
 	{
 		NodeInfoListCell *cell = NULL;
 		ItemList repmgrd_connection_errors = {NULL, NULL};
-		i = 0;
 		int unreachable_node_count = 0;
+		i = 0;
 
 		get_all_node_records(local_conn, &all_nodes);
 
@@ -5675,8 +5673,8 @@ do_standby_switchover(void)
 		{
 			ItemList repmgrd_unpause_errors = {NULL, NULL};
 			NodeInfoListCell *cell = NULL;
-			i = 0;
 			int error_node_count = 0;
+			i = 0;
 
 			for (cell = all_nodes.head; cell; cell = cell->next)
 			{
@@ -6514,8 +6512,8 @@ check_upstream_config(PGconn *conn, int server_version_num, t_node_info *upstrea
 		int		available_wal_senders;
 		int		min_replication_connections			= 1;
 		int		possible_replication_connections	= 0;
-		i											= 0;
 		t_conninfo_param_list repl_conninfo			= T_CONNINFO_PARAM_LIST_INITIALIZER;
+		i											= 0;
 
 
 		/*


### PR DESCRIPTION
Clear warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]

Removed op set _r_ that is never read until it's set to again a few lines below.